### PR TITLE
ibus python binding wasn't working due to incorrect forward-key-event signature

### DIFF
--- a/ibus/engine.py
+++ b/ibus/engine.py
@@ -114,8 +114,8 @@ class EngineBase(object.Object):
         text = serializable.serialize_object(text)
         return self.__proxy.CommitText(text)
 
-    def forward_key_event(self, keyval, state):
-        return self.__proxy.ForwardKeyEvent(keyval, state)
+    def forward_key_event(self, keyval, keycode, state):
+        return self.__proxy.ForwardKeyEvent(keyval, keycode, state)
 
     def update_preedit_text(self, text, cursor_pos, visible, mode=common.IBUS_ENGINE_PREEDIT_CLEAR):
         text = serializable.serialize_object(text)

--- a/ibus/interface/iengine.py
+++ b/ibus/interface/iengine.py
@@ -104,8 +104,8 @@ class IEngine(dbus.service.Object):
     @signal(signature="v")
     def CommitText(self, text): pass
 
-    @signal(signature="uu")
-    def ForwardKeyEvent(self, keyval, state): pass
+    @signal(signature="uuu")
+    def ForwardKeyEvent(self, keyval, keycode, state): pass
 
     @signal(signature="vubu")
     def UpdatePreeditText(self, text, cursor_pos, visible, mode): pass


### PR DESCRIPTION
I corrected according to corresponding ibus C binding:
  http://ibus.googlecode.com/svn/docs/ibus/IBusEngine.html#ibus-engine-forward-key-event
