### PR TITLE
Fix tiny typo which cause unexpected path access.

### DIFF
--- a/docs/reference/ibus/Makefile.am
+++ b/docs/reference/ibus/Makefile.am
@@ -117,7 +117,7 @@ trim-build.stamp: scan-build.stamp
 	$(AM_V_GEN) \
 	    $(SED) -f $(srcdir)/trim.sed -i.bak \
 			$(builddir)/$(DOC_MODULE)-sections.txt && \
-	    $(RM) $(buildir)/$(DOC_MODULE)-sections.txt.bak && \
+	    $(RM) $(builddir)/$(DOC_MODULE)-sections.txt.bak && \
 	    touch trim-build.stamp
 
 tmpl-build.stamp: trim-build.stamp  $(DOC_MODULE)-decl.txt $(SCANOBJ_FILES) $(DOC_MODULE)-overrides.txt


### PR DESCRIPTION
This Makefile.am has tiny typo which cause the build process try to rm /$(DOC_MODULE)-sections.txt.bak
