### PR TITLE
Fix red colour in rgb value in pango.vala

### DIFF
--- a/ui/gtk3/pango.vala
+++ b/ui/gtk3/pango.vala
@@ -50,7 +50,7 @@ Pango.AttrList get_pango_attr_list_from_ibus_text(IBus.Text text) {
         switch(attr.type) {
         case IBus.AttrType.FOREGROUND:
             {
-                uint16 r = (uint16)(attr.value & 0x00ff0000) >> 8;
+                uint16 r = (uint16)((attr.value & 0x00ff0000) >> 8);
                 uint16 g = (uint16)(attr.value & 0x0000ff00);
                 uint16 b = (uint16)(attr.value & 0x000000ff) << 8;
                 pango_attr = Pango.attr_foreground_new(r, g, b);
@@ -58,7 +58,7 @@ Pango.AttrList get_pango_attr_list_from_ibus_text(IBus.Text text) {
             }
         case IBus.AttrType.BACKGROUND:
             {
-                uint16 r = (uint16)(attr.value & 0x00ff0000) >> 8;
+                uint16 r = (uint16)((attr.value & 0x00ff0000) >> 8);
                 uint16 g = (uint16)(attr.value & 0x0000ff00);
                 uint16 b = (uint16)(attr.value & 0x000000ff) << 8;
                 pango_attr = Pango.attr_background_new(r, g, b);


### PR DESCRIPTION
The red part of the rgb value was always passed as 0
to Pango.attr_foreground_new(r, g, b) and
Pango.attr_background_new(r, g, b).
