### PR TITLE
clients can choose whether to commit preedit text before resetting im or not

### DIFF
--- a/bus/ibusimpl.h
+++ b/bus/ibusimpl.h
@@ -79,6 +79,8 @@ BusComponent    *bus_ibus_impl_lookup_component_by_name
 gboolean         bus_ibus_impl_is_use_sys_layout    (BusIBusImpl        *ibus);
 gboolean         bus_ibus_impl_is_embed_preedit_text
                                                     (BusIBusImpl        *ibus);
+gboolean         bus_ibus_impl_is_commit_preedit_text_before_resetting_im
+                                                    (BusIBusImpl        *ibus);
 BusInputContext *bus_ibus_impl_get_focused_input_context
                                                     (BusIBusImpl        *ibus);
 

--- a/data/dconf/ibus.convert
+++ b/data/dconf/ibus.convert
@@ -1,5 +1,6 @@
 [org.freedesktop.ibus.general]
 embed-preedit-text = /desktop/ibus/general/embed_preedit_text
+commit-preedit-text-before-resetting-im = /desktop/ibus/general/commit_preedit_text_before_resetting_im
 enable-by-default = /desktop/ibus/general/enable_by_default
 preload-engines = /desktop/ibus/general/preload_engines
 use-global-engine = /desktop/ibus/general/use_global_engine

--- a/data/ibus.schemas.in
+++ b/data/ibus.schemas.in
@@ -359,7 +359,17 @@
 	    <long>Share the same input method among all applications</long>
       </locale>
     </schema>
-
+    <schema>
+      <key>/schemas/desktop/ibus/general/commit_preedit_text_before_resetting_im</key>
+      <applyto>/desktop/ibus/general/commit_preedit_text_before_resetting_im</applyto>
+      <owner>ibus</owner>
+      <type>bool</type>
+      <default>true</default>
+      <locale name="C">
+        <short>Commit preedit text before resetting input method</short>
+        <long>Commit preedit text before resetting input method</long>
+      </locale>
+    </schema>
     <schema>
       <key>/schemas/desktop/ibus/general/enable_by_default</key>
       <applyto>/desktop/ibus/general/enable_by_default</applyto>

--- a/setup/main.py
+++ b/setup/main.py
@@ -201,6 +201,14 @@ class Setup(object):
                                     'active',
                                     Gio.SettingsBindFlags.DEFAULT)
 
+        # commit preedit text before resetting im
+        self.__commit_preedit_text_before_resetting_im = self.__builder.get_object(
+                "checkbutton_commit_preedit_text_before_resetting_im")
+        self.__settings_general.bind('commit-preedit-text-before-resetting-im',
+                                    self.__commit_preedit_text_before_resetting_im,
+                                    'active',
+                                    Gio.SettingsBindFlags.DEFAULT)
+
         # init engine page
         self.__engines = self.__bus.list_engines()
         self.__combobox = self.__builder.get_object("combobox_engines")

--- a/setup/setup.ui
+++ b/setup/setup.ui
@@ -1056,6 +1056,23 @@
                                         <property name="position">0</property>
                                       </packing>
                                     </child>
+                                    <child>
+                                      <object class="GtkCheckButton" id="checkbutton_commit_preedit_text_before_resetting_im">
+                                        <property name="label" translatable="yes">Commit preedit text before resetting input method</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="use_action_appearance">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="draw_indicator">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
                                   </object>
                                 </child>
                               </object>

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -143,6 +143,10 @@ class Panel : IBus.PanelService {
                 set_embed_preedit_text();
         });
 
+        m_settings_general.changed["commit-preedit-text-before-resetting-im"].connect((key) => {
+                set_commit_preedit_text_before_resetting_im();
+        });
+
         m_settings_general.changed["use-global-engine"].connect((key) => {
                 set_use_global_engine();
         });
@@ -492,6 +496,17 @@ class Panel : IBus.PanelService {
         m_bus.set_ibus_property("EmbedPreeditText", variant);
     }
 
+    private void set_commit_preedit_text_before_resetting_im() {
+        Variant variant =
+                    m_settings_general.get_value("commit-preedit-text-before-resetting-im");
+
+        if (variant == null) {
+            return;
+        }
+
+        m_bus.set_ibus_property("CommitPreeditTextBeforeResettingIM", variant);
+    }
+
     private void set_use_global_engine() {
         m_use_global_engine =
                 m_settings_general.get_boolean("use-global-engine");
@@ -661,6 +676,7 @@ class Panel : IBus.PanelService {
         set_use_system_keyboard_layout();
         set_use_global_engine();
         set_use_xmodmap();
+        set_commit_preedit_text_before_resetting_im();
         update_engines(m_settings_general.get_strv("preload-engines"),
                        m_settings_general.get_strv("engines-order"));
         unbind_switch_shortcut();


### PR DESCRIPTION
When clicking mouse, last preedit text is not committed and it follows mouse cursor.
https://code.google.com/p/ibus/issues/detail?id=1264

Cause 1:
ibus_im_context_filter_keypress() with --enable-key-snooper always returns FALSE, so GtkTextView doesn't reset input method properly.

Cause 2:
If there is commit() in reset(), reset() doesn't wait commit(), so last preedit text is committed after reset().

If you compile with --disable-key-snooper, this approach using ibus property(CommitPreeditTextBeforeResettingIM) can solve the bug.
Clients can choose whether to commit preedit text before resetting im or not, checking ibus_bus_get_ibus_property (bus, "CommitPreeditTextBeforeResettingIM")