### PR TITLE
dconf: Work around using dbus development builds and /etc/machine-id

### DIFF
--- a/data/dconf/make-dconf-override-db.sh
+++ b/data/dconf/make-dconf-override-db.sh
@@ -2,6 +2,10 @@
 
 set -e
 
+# gnome-continuous doesn't have a machine-id set, which
+# breaks dbus-launch.  There's dbus-run-session which is
+# better, but not everyone has it yet.
+export DBUS_FATAL_WARNINGS=0
 export TMPDIR=$(mktemp -d --tmpdir="$PWD")
 export XDG_CONFIG_HOME="$TMPDIR/config"
 export XDG_CACHE_HOME="$TMPDIR/cache"


### PR DESCRIPTION
Recent DBus changed the way it reads /etc/machine-id to be more
strict, and it turns out that this breaks the use of dbus-launch here.

The *correct* fix is to use `dbus-run-session`, but not everyone has
that yet.  This is a quick hack that keeps the build going.