### PR TITLE
Send an absolute path to indicator

### DIFF
--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -1248,9 +1248,7 @@ class Panel : IBus.PanelService {
                 m_status_icon.set_from_file(icon_name);
             }
             else if (m_icon_type == IconType.INDICATOR) {
-                warning("appindicator requires an icon name in a theme " +
-                        "path instead of the full path: %s", icon_name);
-                m_indicator.set_icon_full("ibus-engine", "");
+                m_indicator.set_icon_full(icon_name, "");
             }
         } else {
             string language = null;


### PR DESCRIPTION
KDE status notifier item accepts an absolute path to an icon. So send it to the indicator.