### PR TITLE
check for x11 for the ui too

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -555,6 +555,10 @@ AC_ARG_ENABLE(ui,
 )
 AM_CONDITIONAL([ENABLE_UI], [test x"$enable_ui" = x"yes"])
 if test x"$enable_ui" = x"yes"; then
+    # Check for x11
+    PKG_CHECK_MODULES(X11, [
+        x11
+    ])
     enable_ui="yes (enabled, use --disable-ui to disable)"
 fi
 


### PR DESCRIPTION
if built with --enable-ui --disable-xim it currently fails because X11_LIBS is empty

Signed-off-by: Marc-Antoine Perennou <Marc-Antoine@Perennou.com>