### PR TITLE
dconf: ship gschema.xml.in

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -21,13 +21,10 @@
 # USA
 
 SUBDIRS = \
+	dconf \
 	icons \
 	keymaps \
 	$(NULL)
-
-if ENABLE_DCONF
-SUBDIRS += dconf
-endif
 
 schemasdir = $(GCONF_SCHEMA_FILE_DIR)
 schemas_in_files = ibus.schemas.in

--- a/data/dconf/Makefile.am
+++ b/data/dconf/Makefile.am
@@ -22,11 +22,25 @@
 # USA
 
 gsettings_schemas_in_files = org.freedesktop.ibus.gschema.xml.in
-gsettings_SCHEMAS = $(gsettings_schemas_in_files:.gschema.xml.in=.gschema.xml)
 gsettingsconvertdir = $(datadir)/GConf/gsettings
+dconfprofiledir = $(sysconfdir)/dconf/profile
+dconfdbdir = $(sysconfdir)/dconf/db/ibus.d
+
+if ENABLE_DCONF
+gsettings_SCHEMAS = $(gsettings_schemas_in_files:.gschema.xml.in=.gschema.xml)
 dist_gsettingsconvert_DATA = ibus.convert
+
+dconfprofile_DATA = profile/ibus
+dconfdb_DATA = 00-upstream-settings
+
 @GSETTINGS_RULES@
 @INTLTOOL_XML_NOMERGE_RULE@
+
+install-data-hook:
+	if test -z "$(DESTDIR)"; then \
+		dconf update; \
+	fi
+endif
 
 EXTRA_DIST = \
 	$(gsettings_schemas_in_files) \
@@ -44,12 +58,6 @@ MAINTAINERCLEANFILES = \
 	00-upstream-settings \
 	$(NULL)
 
-dconfprofiledir = $(sysconfdir)/dconf/profile
-dconfprofile_DATA = profile/ibus
-
-dconfdbdir = $(sysconfdir)/dconf/db/ibus.d
-dconfdb_DATA = 00-upstream-settings
-
 org.freedesktop.ibus.gschema.xml.in: $(top_srcdir)/data/ibus.schemas.in
 	$(AM_V_GEN) gsettings-schema-convert --force --gconf --xml \
 		--schema-id "org.freedesktop.ibus" \
@@ -59,10 +67,5 @@ org.freedesktop.ibus.gschema.xml.in: $(top_srcdir)/data/ibus.schemas.in
 	@$(MKDIR_P) db
 	$(AM_V_GEN) $(srcdir)/make-dconf-override-db.sh > $@ || \
 		{ rc=$$?; $(RM) -rf $@; exit $$rc; }
-
-install-data-hook:
-	if test -z "$(DESTDIR)"; then \
-		dconf update; \
-	fi
 
 -include $(top_srcdir)/git.mk


### PR DESCRIPTION
Most people chosing dconf don't have gconf installed, and the conversion tool it part of gconf.

Provider the gschema once and for all.

Signed-off-by: Marc-Antoine Perennou <Marc-Antoine@Perennou.com>