### PR TITLE
provide default in case IBUS_PREFIX environment variable is unset

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -501,7 +501,7 @@ class Setup(object):
     def __is_auto_start(self):
         link_file = path.join(GLib.get_user_config_dir(),
                               "autostart/ibus.desktop")
-        ibus_desktop = path.join(os.getenv("IBUS_PREFIX"),
+        ibus_desktop = path.join(os.getenv("IBUS_PREFIX", ""),
                                  "share/applications/ibus.desktop")
 
         if not path.exists(link_file):
@@ -519,7 +519,7 @@ class Setup(object):
 
         link_file = path.join(GLib.get_user_config_dir(),
                               "autostart/ibus.desktop")
-        ibus_desktop = path.join(os.getenv("IBUS_PREFIX"),
+        ibus_desktop = path.join(os.getenv("IBUS_PREFIX", ""),
                                  "share/applications/ibus.desktop")
         # unlink file
         try:


### PR DESCRIPTION
I was not able to run ibus-setup. It raised an error when it tried
to join the result of os.getenv("IBUS_PREFIX") which was None in
my case. Providing an empty string as default solved my problem
and the setup interface was running without problems.