### PR TITLE
Don't warn if DISPLAY is not set

### DIFF
--- a/src/ibusshare.c
+++ b/src/ibusshare.c
@@ -113,10 +113,7 @@ ibus_get_socket_path (void)
             display = g_strdup (_display);
         }
 
-        if (display == NULL) {
-            g_warning ("DISPLAY is empty! We use default DISPLAY (:0.0)");
-        }
-        else {
+        if (display) {
             p = display;
             hostname = display;
             for (; *p != ':' && *p != '\0'; p++);


### PR DESCRIPTION
This is normal under Wayland, and not worth warning about.
The warnings disrupt unit tests in GNOME continuous, which
treat warnings as fatal.