### PR TITLE
Install a DBus service file

### DIFF
--- a/bus/Makefile.am
+++ b/bus/Makefile.am
@@ -174,4 +174,15 @@ man_onedir = $(mandir)/man1
 %.1.gz: %.1
 	$(AM_V_GEN) gzip -c $< > $@.tmp && mv $@.tmp $@
 
+
+dbusservice_in_files = org.freedesktop.IBus.service.in
+dbusservice_DATA = $(dbusservice_in_files:.service.in=.service)
+dbusservicedir=${datadir}/dbus-1/services
+
+org.freedesktop.IBus.service: org.freedesktop.IBus.service.in
+	$(AM_V_GEN) sed -e "s|\@bindir\@|$(bindir)|" $< > $@.tmp && mv $@.tmp $@
+
+EXTRA_DIST += $(dbusservice_in_files)
+CLEANFILES += $(dbusservice_DATA)
+
 -include $(top_srcdir)/git.mk

--- a/bus/org.freedesktop.IBus.service.in
+++ b/bus/org.freedesktop.IBus.service.in
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.IBus
+Exec=@bindir@/ibus-daemon --replace --xim --panel disable


### PR DESCRIPTION
With the transition to user scoped DBus sessions (vs. login sessions)
there's a need to start ibus-daemon via DBus activation so that the
process gets properly tracked and disposed of when the login session
ends. Otherwise the ibus-daemon process lingers on and keeps the whole
login session up.

We already connect and own a well known name on DBus. The remaining
missing piece is the DBus service file which we introduce here.

---

Would this patch or something like it be acceptable to have upstream in ibus ? We probably want a way to specify the ibus-daemon arguments in a different way?