### PR TITLE
Fix GVariant leaks

### DIFF
--- a/bus/inputcontext.c
+++ b/bus/inputcontext.c
@@ -673,8 +673,10 @@ bus_input_context_send_signal (BusInputContext *context,
                                GVariant        *parameters,
                                GError         **error)
 {
-    if (context->connection == NULL)
+    if (context->connection == NULL) {
+        g_variant_unref (parameters);
         return TRUE;
+    }
 
     GDBusMessage *message = g_dbus_message_new_signal (ibus_service_get_object_path ((IBusService *)context),
                                                        interface_name,
@@ -704,8 +706,10 @@ bus_input_context_emit_signal (BusInputContext *context,
                                GVariant        *parameters,
                                GError         **error)
 {
-    if (context->connection == NULL)
+    if (context->connection == NULL) {
+        g_variant_unref (parameters);
         return TRUE;
+    }
 
     return bus_input_context_send_signal (context,
                                           "org.freedesktop.IBus.InputContext",


### PR DESCRIPTION
The expectation is that g_dbus_message_set_body() takes ownership of the
GVariant, but this does not happen if the BusInputContext connection is NULL.
Call g_variant_unref() in that case to free the memory. Alternatively, a
GVariantBuilder could be used.

Valgrind shows the leak:
```
==5223== 28,696 (1,360 direct, 27,336 indirect) bytes in 34 blocks are definitely lost in loss record 3,085 of 3,092
==5223==    at 0x4C2DB8F: malloc (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==5223==    by 0x54646A8: g_malloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.0)
==5223==    by 0x547B8B2: g_slice_alloc (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.0)
==5223==    by 0x5499E0D: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.0)
==5223==    by 0x5496B1B: g_variant_builder_end (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.0)
==5223==    by 0x5498552: ??? (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.0)
==5223==    by 0x54989C1: g_variant_new_va (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.0)
==5223==    by 0x5498C3C: g_variant_new (in /lib/x86_64-linux-gnu/libglib-2.0.so.0.4800.0)
==5223==    by 0x40F1CB: bus_input_context_update_preedit_text (in /usr/bin/ibus-daemon)
==5223==    by 0x411027: bus_input_context_disable (in /usr/bin/ibus-daemon)
==5223==    by 0x4111BA: bus_input_context_set_engine (in /usr/bin/ibus-daemon)
==5223==    by 0x40C18F: bus_ibus_impl_set_focused_context (in /usr/bin/ibus-daemon)
```

Maybe this leak is responsible for https://bugs.launchpad.net/ubuntu/+source/ibus/+bug/1324728 too.