### PR TITLE
Fix memory leak in ibus-ui-gtk3

### DIFF
--- a/src/ibusbus.h
+++ b/src/ibusbus.h
@@ -977,7 +977,7 @@ gboolean     ibus_bus_is_global_engine_enabled_async_finish
  *
  * Get the description of current global engine synchronously.
  *
- * Returns: (transfer none): The description of current global engine,
+ * Returns: (transfer full): The description of current global engine,
  * or %NULL if there is no global engine.
  */
 IBusEngineDesc *

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -1419,12 +1419,6 @@ class Panel : IBus.PanelService {
 
         var engine = m_bus.get_global_engine();
         if (engine != null) {
-            /*
-            get_global_engine() returns a new object with a reference count of 1. Vala 
-            adds another reference because "new IBus.EngineDesc()" isn't used. Remove the 
-            additional reference so the engine is eventually freed.
-            */
-            engine.unref();
             icon_name = engine.get_icon();
             m_icon_prop_key = engine.get_icon_prop_key();
         } else {

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -1419,6 +1419,12 @@ class Panel : IBus.PanelService {
 
         var engine = m_bus.get_global_engine();
         if (engine != null) {
+            /*
+            get_global_engine() returns a new object with a reference count of 1. Vala 
+            adds another reference because "new IBus.EngineDesc()" isn't used. Remove the 
+            additional reference so the engine is eventually freed.
+            */
+            engine.unref();
             icon_name = engine.get_icon();
             m_icon_prop_key = engine.get_icon_prop_key();
         } else {


### PR DESCRIPTION
get_global_engine() returns a new object with a reference count of 1. Vala
adds another reference because "new IBus.EngineDesc()" isn't used. Remove the
additional reference so the engine is eventually freed.

Valgrind:
```
22,555 (4,160 direct, 18,395 indirect) bytes in 65 blocks are definitely lost in loss record 8,904 of 8,914
   at 0x733B3E7: g_type_create_instance (gtype.c:1845)
   by 0x731CCD7: g_object_constructor (gobject.c:2068)
   by 0x731D028: g_object_new_with_custom_constructor (gobject.c:1701)
   by 0x731D028: g_object_new_internal (gobject.c:1781)
   by 0x731EC0C: g_object_newv (gobject.c:1930)
   by 0x731F3C3: g_object_new (gobject.c:1623)
   by 0x68F5FDB: ibus_serializable_deserialize (ibusserializable.c:292)
   by 0x690AF7B: ibus_bus_get_global_engine (ibusbus.c:2002)
   by 0x120E2A: panel_real_state_changed (panel.c:5371)
   by 0x7317F74: g_closure_invoke (gclosure.c:804)
   by 0x732A37C: signal_emit_unlocked_R (gsignal.c:3673)
   by 0x7332BCB: g_signal_emit_valist (gsignal.c:3391)
   by 0x7332FAE: g_signal_emit (gsignal.c:3447)
```