### PR TITLE
ibus-setup: Add option to change tray icon color

### DIFF
--- a/data/dconf/ibus.convert
+++ b/data/dconf/ibus.convert
@@ -21,5 +21,6 @@ show = /desktop/ibus/general/show
 show-icon-on-systray = /desktop/ibus/general/show_icon_on_systray
 show-im-name = /desktop/ibus/general/show_im_name
 use-custom-font = /desktop/ibus/general/use_custom_font
+use-custom-icon-color = /desktop/ibus/general/use_custom_icon_color
 x = /desktop/ibus/general/x
 y = /desktop/ibus/general/y

--- a/data/ibus.schemas.in
+++ b/data/ibus.schemas.in
@@ -354,6 +354,17 @@
       </locale>
     </schema>
     <schema>
+      <key>/schemas/desktop/ibus/panel/use_custom_icon_color</key>
+      <applyto>/desktop/ibus/panel/use_custom_icon_color</applyto>
+      <owner>ibus</owner>
+      <type>bool</type>
+      <default>false</default>
+      <locale name="C">
+        <short>Use custom tray icon color</short>
+	    <long>Use custom color in the system tray icon</long>
+      </locale>
+    </schema>
+    <schema>
       <key>/schemas/desktop/ibus/panel/emoji/hotkey</key>
       <applyto>/desktop/ibus/panel/emoji/hotkey</applyto>
       <owner>ibus</owner>

--- a/setup/Makefile.am
+++ b/setup/Makefile.am
@@ -22,6 +22,7 @@
 # USA
 
 ibussetup_PYTHON = \
+	colorbutton.py \
     emojilang.py \
     enginecombobox.py \
     enginedialog.py \

--- a/setup/colorbutton.py
+++ b/setup/colorbutton.py
@@ -1,0 +1,69 @@
+# vim:set et sts=4 sw=4:
+# -*- coding: utf-8 -*-
+#
+# ibus - The Input Bus
+#
+# Copyright (c) 2017 Ricardo Maes <ricmzn@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+from gi import require_version as gi_require_version
+gi_require_version('Gdk', '3.0')
+gi_require_version('Gtk', '3.0')
+
+from gi.repository import GObject
+from gi.repository import Gdk
+from gi.repository import Gtk
+
+class IBusSetupColorButton(Gtk.ColorButton):
+    __gtype_name__ = "IBusSetupColorButton"
+
+    # Property for notify events
+    rgba_string = GObject.Property(type=str)
+
+    def __init__(self):
+        Gtk.ColorButton.__init__(self)
+        # Actual RGBA string value
+        self.rgba_string_internal = ""
+        # Tell GTK+ to inform us when the color button is changed so we can update the string value
+        self.connect("notify::rgba", self.on_color_change)
+
+    def set_custom_checkbutton(self, custom_checkbutton):
+        # Checkbutton controlling the use of custom color
+        self.custom_checkbutton = custom_checkbutton
+        # Notify our property when the button state changes
+        self.custom_checkbutton.connect("notify::active", self.on_color_change)
+
+    @GObject.Property(type=str)
+    def rgba_string(self):
+        if self.custom_checkbutton.get_active():
+            # Use the user-defined color
+            return self.rgba_string_internal
+        else:
+            # Use the default dark blue color as defined in the DBus schema
+            return "#415099"
+
+    @rgba_string.setter
+    def rgba_string(self, value):
+        # Avoid looping back from the notify event by checking if the value is the same from the last call
+        if value != self.rgba_string_internal:
+            self.rgba_string_internal = value
+            rgba = Gdk.RGBA()
+            rgba.parse(value)
+            self.set_rgba(rgba)
+
+    def on_color_change(self, gparamstring, spec):
+        self.rgba_string = self.get_rgba().to_string()

--- a/setup/main.py
+++ b/setup/main.py
@@ -57,6 +57,7 @@ from enginedialog import EngineDialog
 from enginetreeview import EngineTreeView
 from engineabout import EngineAbout
 from i18n import DOMAINNAME, _, N_
+from colorbutton import IBusSetupColorButton
 
 (
     COLUMN_NAME,
@@ -111,7 +112,7 @@ class Setup(object):
         gtk_builder_file = path.join(path.dirname(__file__), "./setup.ui")
         self.__builder = Gtk.Builder()
         self.__builder.set_translation_domain(DOMAINNAME)
-        self.__builder.add_from_file(gtk_builder_file);
+        self.__builder.add_from_file(gtk_builder_file)
         self.__init_ui()
 
     def __init_hotkeys(self):
@@ -195,6 +196,27 @@ class Setup(object):
                                    self.__checkbutton_show_icon_on_systray,
                                    'active',
                                    Gio.SettingsBindFlags.DEFAULT)
+
+        # use custom icon color on system tray
+        self.__checkbutton_custom_icon_color = self.__builder.get_object(
+                "checkbutton_custom_icon_color")
+        self.__settings_panel.bind('use-custom-icon-color',
+                                   self.__checkbutton_custom_icon_color,
+                                   'active',
+                                   Gio.SettingsBindFlags.DEFAULT)
+
+        # icon color button
+        self.__colorbutton_custom_icon_color = self.__builder.get_object(
+                "colorbutton_custom_icon_color")
+        self.__colorbutton_custom_icon_color.set_custom_checkbutton(self.__checkbutton_custom_icon_color)
+        self.__settings_panel.bind('xkb-icon-rgba',
+                                   self.__colorbutton_custom_icon_color,
+                                   'rgba-string',
+                                   Gio.SettingsBindFlags.DEFAULT)
+        self.__settings_panel.bind('use-custom-icon-color',
+                                    self.__colorbutton_custom_icon_color,
+                                   'sensitive',
+                                   Gio.SettingsBindFlags.GET)
 
         # show ime name
         self.__checkbutton_show_im_name = self.__builder.get_object(

--- a/setup/setup.ui
+++ b/setup/setup.ui
@@ -379,7 +379,7 @@
                       <object class="GtkTable" id="table2">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="n_rows">7</property>
+                        <property name="n_rows">8</property>
                         <property name="n_columns">2</property>
                         <property name="column_spacing">12</property>
                         <property name="row_spacing">6</property>
@@ -502,8 +502,8 @@
                           </object>
                           <packing>
                             <property name="right_attach">2</property>
-                            <property name="top_attach">3</property>
-                            <property name="bottom_attach">4</property>
+                            <property name="top_attach">6</property>
+                            <property name="bottom_attach">7</property>
                             <property name="x_options">GTK_FILL</property>
                             <property name="y_options">GTK_FILL</property>
                           </packing>
@@ -522,8 +522,8 @@
                           </object>
                           <packing>
                             <property name="right_attach">2</property>
-                            <property name="top_attach">4</property>
-                            <property name="bottom_attach">5</property>
+                            <property name="top_attach">3</property>
+                            <property name="bottom_attach">4</property>
                             <property name="x_options">GTK_FILL</property>
                             <property name="y_options">GTK_FILL</property>
                           </packing>
@@ -542,8 +542,8 @@
                           </object>
                           <packing>
                             <property name="right_attach">2</property>
-                            <property name="top_attach">5</property>
-                            <property name="bottom_attach">6</property>
+                            <property name="top_attach">4</property>
+                            <property name="bottom_attach">5</property>
                             <property name="x_options">GTK_FILL</property>
                             <property name="y_options">GTK_FILL</property>
                           </packing>
@@ -561,8 +561,8 @@
                             <property name="draw_indicator">True</property>
                           </object>
                           <packing>
-                            <property name="top_attach">6</property>
-                            <property name="bottom_attach">7</property>
+                            <property name="top_attach">5</property>
+                            <property name="bottom_attach">6</property>
                             <property name="x_options">GTK_FILL</property>
                             <property name="y_options">GTK_FILL</property>
                           </packing>
@@ -577,8 +577,43 @@
                           <packing>
                             <property name="left_attach">1</property>
                             <property name="right_attach">2</property>
-                            <property name="top_attach">6</property>
-                            <property name="bottom_attach">7</property>
+                            <property name="top_attach">5</property>
+                            <property name="bottom_attach">6</property>
+                            <property name="y_options">GTK_FILL</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="checkbutton_custom_icon_color">
+                            <property name="label" translatable="yes">Use custom tray icon color:</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="halign">start</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="top_attach">7</property>
+                            <property name="bottom_attach">8</property>
+                            <property name="x_options">GTK_FILL</property>
+                            <property name="y_options">GTK_FILL</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="IBusSetupColorButton" id="colorbutton_custom_icon_color">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="use_action_appearance">False</property>
+                            <property name="show_editor">True</property>
+                            <property name="use_alpha">False</property>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="right_attach">2</property>
+                            <property name="top_attach">7</property>
+                            <property name="bottom_attach">8</property>
                             <property name="y_options">GTK_FILL</property>
                           </packing>
                         </child>


### PR DESCRIPTION
This PR adds an extra button to ibus-setup, which allows the user to change the tray icon color. It also moves the tray icon toggle checkbox to just above the new button, making the relationship between the two settings more apparent (unecessary, but possibly helpful).

Screenshot of ibus-setup after the changes:
![ibus-setup preview](https://user-images.githubusercontent.com/6194377/28506101-3baabf34-6fff-11e7-9966-db52ab7b3e78.png)

I have created this because the default color (dark blue) might not contrast well against the user's panel color, making it hard to read. For example, this is how the icon looks like on Cinnamon with the Arc theme:
![Tray icon, before color change](https://user-images.githubusercontent.com/6194377/28506146-a2d8c250-6fff-11e7-85fe-fc5031d0014c.png)

But by changing the color, it can look much better:
![after](https://user-images.githubusercontent.com/6194377/28506308-d12e2536-7000-11e7-86be-e14598cc7ead.png)

The default color is still used when the user disables the checkbox next to the button, but it's handled by ibus-setup instead of directly in the tray icon application. The new menu item is also lacking translations, so those are welcome.