### PR TITLE
fix compile error: undefined reference to symbol 'g_type_check_instance_is_a'

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -316,6 +316,7 @@ emoji_parser_CFLAGS =           \
 emoji_parser_LDADD =            \
     $(GLIB2_LIBS)               \
     $(libibus)                  \
+    $(GOBJECT2_LIBS)                  \
     $(NULL)
 
 clean-local:


### PR DESCRIPTION
fix compile error: undefined reference to symbol 'g_type_check_instance_is_a'