### PR TITLE
Fix GVariant leaks

### DIFF
--- a/src/ibusbus.c
+++ b/src/ibusbus.c
@@ -755,6 +755,7 @@ _async_finish_object_path (GTask   *task,
     g_variant_get (result, "(v)", &variant);
     path = g_variant_dup_string (variant, NULL);
     g_variant_unref (variant);
+    g_variant_unref (result);
     return path;
 }
 
@@ -772,6 +773,7 @@ _async_finish_string (GTask   *task,
     }
     g_return_val_if_fail (variant != NULL, NULL);
     g_variant_get (variant, "(&s)", &s);
+    g_variant_unref (variant);
     return s;
 }
 
@@ -789,6 +791,7 @@ _async_finish_gboolean (GTask   *task,
     }
     g_return_val_if_fail (variant != NULL, FALSE);
     g_variant_get (variant, "(b)", &retval);
+    g_variant_unref (variant);
     return retval;
 }
 
@@ -807,6 +810,7 @@ _async_finish_guint (GTask   *task,
     }
     g_return_val_if_fail (variant != NULL, bad_id);
     g_variant_get (variant, "(u)", &id);
+    g_variant_unref (variant);
     return id;
 }
 
@@ -1864,6 +1868,7 @@ ibus_bus_list_engines_async_finish (IBusBus      *bus,
     }
     g_variant_iter_free (iter);
     g_variant_unref (variant);
+    g_variant_unref (result);
     return retval;
 }
 
@@ -2243,6 +2248,7 @@ ibus_bus_get_global_engine_async_finish (IBusBus      *bus,
         g_variant_unref (obj);
         g_variant_unref (variant);
     }
+    g_variant_unref (result);
     return engine;
 }
 
@@ -2461,6 +2467,7 @@ ibus_bus_get_ibus_property_async_finish (IBusBus      *bus,
     g_return_val_if_fail (result != NULL, NULL);
     GVariant *retval = NULL;
     g_variant_get (result, "(v)", &retval);
+    g_variant_unref (result);
 
     return retval;
 }


### PR DESCRIPTION
g_task_propagate_pointer() gives ownership of the data to the caller, so
the GVariants handed this way must be unref'ed after the contents have
been extracted/copied.

This was noticed running gnome-shell on valgrind (as it's a libibus user):

==5446== 3,468,198 (240 direct, 3,467,958 indirect) bytes in 6 blocks are definitely lost in loss record 124,218 of 12
4,218
==5446==    at 0x4C2FB6B: malloc (vg_replace_malloc.c:299)
==5446==    by 0x58AFE13: g_malloc (gmem.c:94)
==5446==    by 0x58C63DD: g_slice_alloc (gslice.c:1025)
==5446==    by 0x58E3723: g_variant_alloc (gvariant-core.c:476)
==5446==    by 0x58E3723: g_variant_new_from_children (gvariant-core.c:565)
==5446==    by 0x58E0717: g_variant_builder_end (gvariant.c:3703)
==5446==    by 0x53454F4: parse_value_from_blob (gdbusmessage.c:1739)
==5446==    by 0x534575A: parse_value_from_blob (gdbusmessage.c:1850)
==5446==    by 0x53455DE: parse_value_from_blob (gdbusmessage.c:1770)
==5446==    by 0x53454B8: parse_value_from_blob (gdbusmessage.c:1723)
==5446==    by 0x534569B: parse_value_from_blob (gdbusmessage.c:1804)
==5446==    by 0x5346B8B: g_dbus_message_new_from_blob (gdbusmessage.c:2146)
==5446==    by 0x535097B: _g_dbus_worker_do_read_cb (gdbusprivate.c:744)
==5446==    by 0x530D3B4: g_task_return_now (gtask.c:1145)
==5446==    by 0x530D3FC: complete_in_idle_cb (gtask.c:1159)
==5446==    by 0x58A7B89: g_idle_dispatch (gmain.c:5500)
==5446==    by 0x58AAE9E: g_main_dispatch (gmain.c:3148)
==5446==    by 0x58AAE9E: g_main_context_dispatch (gmain.c:3813)
==5446==    by 0x58AB15B: g_main_context_iterate (gmain.c:3886)
==5446==    by 0x58AB4A7: g_main_loop_run (gmain.c:4082)
==5446==    by 0x534EDEA: gdbus_shared_thread_func (gdbusprivate.c:275)
==5446==    by 0x58CFE87: g_thread_proxy (gthread.c:784)
==5446==    by 0x760A608: start_thread (in /usr/lib64/libpthread-2.26.so)
==5446==    by 0x793BE6E: clone (in /usr/lib64/libc-2.26.so)

This rather generic backtrace points out that GVariants from DBus replies are being leaked. Some investigation of the DBus traffic seemed to point to IBus, and effectively this patch greatly reduces amount of memory leaked here.