### PR TITLE
Put back the hex input start key check.

### DIFF
--- a/src/ibusenginesimple.c
+++ b/src/ibusenginesimple.c
@@ -1075,6 +1075,7 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
         have_hex_mods = (modifiers & (HEX_MOD_MASK)) == HEX_MOD_MASK;
     }
 
+    is_hex_start = keyval == IBUS_KEY_U;
     is_hex_end = (keyval == IBUS_KEY_space ||
                   keyval == IBUS_KEY_KP_Space ||
                   keyval == IBUS_KEY_Return ||


### PR DESCRIPTION
  This was accidentally removed by ["Move emoji implementation from IBusEngineSimple to IBusPanel"](https://github.com/ibus/ibus/commit/02d99aa00cb4a26a2cfb6098ea27e763e9bb2daa#diff-d13f2f35e6ae7938c61d89d377e27184L1058).

Resolves #1961 