### PR TITLE
ibus/*.py: Switch "import gobject" to "from gi.repository import GObj…

### DIFF
--- a/ibus/bus.py
+++ b/ibus/bus.py
@@ -28,7 +28,7 @@ import dbus
 import dbus.lowlevel
 import dbus.connection
 import dbus.mainloop.glib
-import gobject
+from gi.repository import GObject as gobject
 import common
 import object
 import serializable

--- a/ibus/common.py
+++ b/ibus/common.py
@@ -176,7 +176,7 @@ __mainloop = None
 def __init_main_loop():
     global __mainloop
     if __mainloop == None:
-        import gobject
+        from gi.repository import GObject as gobject
         __mainloop = gobject.MainLoop()
 
 def main():

--- a/ibus/config.py
+++ b/ibus/config.py
@@ -29,7 +29,7 @@ __all__ = (
 IBUS_SERVICE_CONFIG = "org.freedesktop.IBus.Config"
 IBUS_PATH_CONFIG = "/org/freedesktop/IBus/Config"
 
-import gobject
+from gi.repository import GObject as gobject
 import object
 import interface
 import dbus

--- a/ibus/inputcontext.py
+++ b/ibus/inputcontext.py
@@ -25,7 +25,7 @@ __all__ = (
     )
 
 import sys
-import gobject
+from gi.repository import GObject as gobject
 import dbus
 import dbus.lowlevel
 import object

--- a/ibus/object.py
+++ b/ibus/object.py
@@ -24,7 +24,7 @@ __all__ = (
         "Object",
     )
 
-import gobject
+from gi.repository import GObject as gobject
 
 class Object(gobject.GObject):
     __gtype_name__ = "PYIBusObject"

--- a/ibus/serializable.py
+++ b/ibus/serializable.py
@@ -28,7 +28,8 @@ __all__ = (
 
 from object import Object
 import dbus
-import gobject
+from gi.repository import GObject as gobject
+from gi.types import GObjectMeta
 
 __serializable_name_dict = dict()
 
@@ -55,7 +56,7 @@ def deserialize_object(v):
         return o
     return v
 
-class SerializableMeta(gobject.GObjectMeta):
+class SerializableMeta(GObjectMeta):
     def __init__(cls, name, bases, dict_):
         super(SerializableMeta, cls).__init__(name, bases, dict_)
         if "__NAME__" in cls.__dict__:


### PR DESCRIPTION
…ect"

According to the fix of https://bugzilla.gnome.org/show_bug.cgi?id=709183,
import static binding of gobject is protected when gi.repository is used.
This becomes an issue when ibus is imported altogether with gi.repository.
The following example will populate an _static_binding_error mentioned in the
bug:

    >>> from gi.repository import Gtk
    >>> import ibus