### PR TITLE
Fix ucd directory override

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -666,7 +666,7 @@ AC_ARG_WITH(ucd-dir,
     AS_HELP_STRING([--with-ucd-dir[=DIR]],
         [Set the directory of UCD (Unicode Character Database) files.
          (default: "/usr/share/unicode/ucd")]),
-    UCD_DIR=$with_emoji_annotation_dir,
+    UCD_DIR=$with_ucd_dir,
     UCD_DIR="/usr/share/unicode/ucd"
 )
 AC_SUBST(UCD_DIR)


### PR DESCRIPTION
This is needed on Debian where _unicode-data_ installs to `/usr/share/unicode/NamesList.txt` instead of to `/usr/share/unicode/ucd/NamesList.txt`