### PR TITLE
Remove a misleading "const" modifier of a return value

### DIFF
--- a/src/ibuskeynames.c
+++ b/src/ibuskeynames.c
@@ -124,7 +124,7 @@ modifier_name[] = {
     NULL,        // 31
 };
 
-const gchar *
+gchar *
 ibus_key_event_to_string (guint keyval,
                           guint modifiers)
 {

--- a/src/ibusshare.h
+++ b/src/ibusshare.h
@@ -326,7 +326,7 @@ void             ibus_free_strv         (gchar          **strv)
  *
  * Returns: The name of a key symbol and modifier.
  */
-const gchar     *ibus_key_event_to_string
+gchar           *ibus_key_event_to_string
                                         (guint           keyval,
                                          guint           modifiers);
 


### PR DESCRIPTION
ibus_key_event_to_string() uses g_string_free(str, FALSE) to return
a string so that users must free it. To clarify it, the const
modifier should be removed.