### PR TITLE
bus: remove obsolete mem-profile option

### DIFF
--- a/bus/main.c
+++ b/bus/main.c
@@ -160,18 +160,6 @@ daemon (gint nochdir, gint noclose)
 }
 #endif
 
-/*
- * _sig_usr2_handler:
- * @sig: the signal number, which is usually SIGUSR2.
- *
- * A signal handler for SIGUSR2 signal. Dump a summary of memory usage to stderr.
- */
-static void
-_sig_usr2_handler (int sig)
-{
-    g_mem_profile ();
-}
-
 gint
 main (gint argc, gchar **argv)
 {
@@ -196,8 +184,7 @@ main (gint argc, gchar **argv)
     }
 
     if (g_mempro) {
-        g_mem_set_vtable (glib_mem_profiler_table);
-        signal (SIGUSR2, _sig_usr2_handler);
+        g_warning ("--mem-profile no longer works with the GLib 2.46 or later");
     }
 
     /* check uid */

--- a/configure.ac
+++ b/configure.ac
@@ -52,12 +52,12 @@ m4_define([ibus_binary_version],
           [ibus_major_version.ibus_abi_current_minus_age.ibus_abi_age.ibus_abi_revision])
 
 # Required versions of other packages.
-m4_define([glib_required_version], [2.36.0])
+m4_define([glib_required_version], [2.46.0])
 
 # VALA_TARGET_GLIB_VERSION is used by valac --ccode --target-glib .
 # VALA_TARGET_GLIB_VERSION and glib_required_version will be different
 # in the future.
-VALA_TARGET_GLIB_VERSION=2.36
+VALA_TARGET_GLIB_VERSION=2.46
 AC_SUBST(VALA_TARGET_GLIB_VERSION)
 
 # Init automake.


### PR DESCRIPTION
Since GLib 2.46, memory profiling feature does not work anymore.

See https://developer.gnome.org/glib/stable/glib-Memory-Allocation.html#g-mem-set-vtable

GLib 2.46 or later means that Ubuntu 16.04 or later. Ubuntu
14.04 (trusty) are still supported as LTS phase, but it seems that
GLib is old enough (2.40) to drop support.