### PR TITLE
Allow passing non-abstract UNIX domain socket addresses to ibus-daemon

### DIFF
--- a/bus/server.c
+++ b/bus/server.c
@@ -144,9 +144,10 @@ bus_server_init (void)
     /* init server */
     GDBusServerFlags flags = G_DBUS_SERVER_FLAGS_AUTHENTICATION_ALLOW_ANONYMOUS;
     gchar *guid = g_dbus_generate_guid ();
-    if (!g_str_has_prefix (g_address, "unix:tmpdir=")) {
-        g_error ("Your socket address does not have the format unix:tmpdir=$DIR; %s",
-                 g_address);
+    if (!g_str_has_prefix (g_address, "unix:tmpdir=") &&
+        !g_str_has_prefix (g_address, "unix:path=")) {
+        g_error ("Your socket address does not have the format unix:tmpdir=$DIR "
+                 "or unix:path=$FILE; %s", g_address);
     }
     server =  g_dbus_server_new_sync (
                     g_address, /* the place where the socket file lives, e.g. /tmp, abstract namespace, etc. */


### PR DESCRIPTION
Small patch that adds support for binding ibus-daemon to non-abstract unix domain sockets. This allows IME clients running within container to communicate with host's ibus-daemon.

This fixes the issue of input not working when running a program (e.g. a browser) in separate network namespace, which is caused by the fact that each network namespace has its own abstract socket namespace and it's not shareable.