### PR TITLE
Save address file in XDG_RUNTIME_DIR

### DIFF
--- a/src/ibusshare.c
+++ b/src/ibusshare.c
@@ -142,7 +142,7 @@ ibus_get_socket_path (void)
                              ibus_get_local_machine_id (),
                              hostname,
                              displaynumber);
-        path = g_build_filename (g_get_user_config_dir (),
+        path = g_build_filename (g_get_user_runtime_dir (),
                                  "ibus",
                                  "bus",
                                  p,


### PR DESCRIPTION
Currently the address file is saved in XDG_CONFIG_DIR, however since it is not a config or preferences file perhaps it should instead be saved to XDG_RUNTIME_DIR.