### PR TITLE
Make session file header comment more clear

### DIFF
--- a/src/ibusshare.c
+++ b/src/ibusshare.c
@@ -251,7 +251,11 @@ ibus_write_address (const gchar *address)
     g_return_if_fail (pf != NULL);
 
     fprintf (pf,
-        "# This file is created by ibus-daemon, please do not modify it\n"
+        "# This file is created by ibus-daemon, please do not modify it.\n"
+        "# This file allows processes on the machine to find the\n"
+        "# ibus session bus with the below address.\n"
+        "# If the IBUS_ADDRESS environment variable is set, it will\n"
+        "# be used rather than this file.\n"
         "IBUS_ADDRESS=%s\n"
         "IBUS_DAEMON_PID=%ld\n",
         address, (glong) getpid ());


### PR DESCRIPTION
Update the header comment in the session file to clarify its use.

Based on the header comment in dbus as seen [here](https://gitlab.freedesktop.org/dbus/dbus/blob/cd4e34408eb911b9fe001a1ac126bd2d74e3cb58/tools/dbus-launch-x11.c#L413).

Anything that parses this file for the address should be skipping comment lines so this commit should not break anything.