### PR TITLE
Fix restart crash

### DIFF
--- a/bus/server.c
+++ b/bus/server.c
@@ -26,6 +26,9 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <stdlib.h>
+#include <stdio.h>
+#include <fcntl.h>
+#include <errno.h>
 #include <string.h>
 
 #include "dbusimpl.h"
@@ -45,6 +48,10 @@ _restart_server (void)
 {
     gchar *exe;
     gint fd;
+    ssize_t r;
+    int MAXSIZE = 0xFFF;
+    char proclnk[MAXSIZE];
+    char filename[MAXSIZE];
 
     exe = g_strdup_printf ("/proc/%d/exe", getpid ());
     exe = g_file_read_link (exe, NULL);
@@ -54,7 +61,21 @@ _restart_server (void)
 
     /* close all fds except stdin, stdout, stderr */
     for (fd = 3; fd <= sysconf (_SC_OPEN_MAX); fd ++) {
-        close (fd);
+        errno = 0;
+        /* only close valid fds */
+        if (fcntl(fd, F_GETFD) != -1 || errno != EBADF) {
+            sprintf(proclnk, "/proc/self/fd/%d", fd);
+            r = readlink(proclnk, filename, MAXSIZE);
+            if (r < 0) {
+                continue;
+            }
+            filename[r] = '\0';
+
+            /* Do not close 'anon_inode:inotify' fds, that may crash in glib */
+            if (strcmp(filename, "anon_inode:inotify") != 0) {
+                close (fd);
+            }
+        }
     }
 
     _restart = FALSE;

--- a/bus/server.c
+++ b/bus/server.c
@@ -26,7 +26,7 @@
 #include <glib/gstdio.h>
 #include <gio/gio.h>
 #include <stdlib.h>
-#include <stdio.h>
+#include <glib/gstdio.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <string.h>
@@ -53,26 +53,25 @@ _restart_server (void)
     char proclnk[MAXSIZE];
     char filename[MAXSIZE];
 
-    exe = g_strdup_printf ("/proc/%d/exe", getpid ());
-    exe = g_file_read_link (exe, NULL);
+    exe = g_file_read_link ("/proc/self/exe", NULL);
 
     if (exe == NULL)
-        exe = BINDIR "/ibus-daemon";
+        exe = g_strdup (BINDIR "/ibus-daemon");
 
     /* close all fds except stdin, stdout, stderr */
     for (fd = 3; fd <= sysconf (_SC_OPEN_MAX); fd ++) {
         errno = 0;
         /* only close valid fds */
-        if (fcntl(fd, F_GETFD) != -1 || errno != EBADF) {
-            sprintf(proclnk, "/proc/self/fd/%d", fd);
-            r = readlink(proclnk, filename, MAXSIZE);
+        if (fcntl (fd, F_GETFD) != -1 || errno != EBADF) {
+            g_sprintf (proclnk, "/proc/self/fd/%d", fd);
+            r = readlink (proclnk, filename, MAXSIZE);
             if (r < 0) {
                 continue;
             }
             filename[r] = '\0';
 
             /* Do not close 'anon_inode:inotify' fds, that may crash in glib */
-            if (strcmp(filename, "anon_inode:inotify") != 0) {
+            if (g_strcmp0 (filename, "anon_inode:inotify") != 0) {
                 close (fd);
             }
         }
@@ -90,6 +89,7 @@ _restart_server (void)
         execv (exe, g_argv);
     }
     g_warning ("execv %s failed!", g_argv[0]);
+    g_free (exe);
     exit (-1);
 }
 


### PR DESCRIPTION
Do not close inotify desciptors when restarting the server. This
may lead to crashes in glib.

Fixes crash in libglib/libgio with GLib-GIO-ERROR : inotify read(): Bad file descriptor

See also src/tests/ibus-bus.c: start_exit_async():
    /* When `./runtest ibus-bus` runs, ibus-daemon sometimes failed to
     * restart because closing a file descriptor was failed in
     * bus/server.c:_restart_server() with a following error:
     *     "inotify read(): Bad file descriptor"

Test plan:
Run
$ ibus restart
several times. Without the patch ibus-daemon will crash occasionally.