### PR TITLE
Add the French bepo_afnor layout

### DIFF
--- a/engine/simple.xml.in
+++ b/engine/simple.xml.in
@@ -284,6 +284,18 @@
                         <rank>1</rank>
                 </engine>
                 <engine>
+                        <name>xkb:fr:bepo_afnor:fra</name>
+                        <language>fr</language>
+                        <license>GPL</license>
+                        <author>Peng Huang &lt;shawn.p.huang@gmail.com&gt;</author>
+                        <layout>fr</layout>
+                        <layout_variant>bepo_afnor</layout_variant>
+                        <longname>French (Bepo, ergonomic, Dvorak way, AFNOR)</longname>
+                        <description>French (Bepo, ergonomic, Dvorak way, AFNOR)</description>
+                        <icon>ibus-keyboard</icon>
+                        <rank>1</rank>
+                </engine>
+                <engine>
                         <name>xkb:fr:dvorak:fra</name>
                         <language>fr</language>
                         <license>GPL</license>


### PR DESCRIPTION
xkeyboard-config 2.28 has got a newer variant of the French bépo layout, called `bepo_afnor`. See https://github.com/freedesktop/xkeyboard-config/commit/973678d23cf2123d054a9d0d371bf2ae929fb894

It’s quite similar to the already existing `bepo` layout variant, so I pretty much took inspiration from it. Here goes.