### PR TITLE
Add NotShowIn and Keywords keys to the setup desktop entry

### DIFF
--- a/setup/ibus-setup.desktop
+++ b/setup/ibus-setup.desktop
@@ -7,3 +7,6 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Settings;
+# GNOME uses its own "input source" settings instead
+NotShowIn=GNOME;Unity;
+Keywords=keyboard;input;


### PR DESCRIPTION
From old Debian package changes:

- Add NotShowIn - Do not show ibus-setup in GNOME and Ubuntu as they use their own settings.
- Add Keywords
