### PR TITLE
Handle small final sigma in ibus_keyval_convert_case

### DIFF
--- a/src/ibuskeynames.c
+++ b/src/ibuskeynames.c
@@ -331,8 +331,9 @@ ibus_keyval_convert_case (guint symbol,
         xupper -= (IBUS_KEY_Greek_alphaaccent - IBUS_KEY_Greek_ALPHAaccent);
       else if (symbol >= IBUS_KEY_Greek_ALPHA && symbol <= IBUS_KEY_Greek_OMEGA)
         xlower += (IBUS_KEY_Greek_alpha - IBUS_KEY_Greek_ALPHA);
-      else if (symbol >= IBUS_KEY_Greek_alpha && symbol <= IBUS_KEY_Greek_omega &&
-               symbol != IBUS_KEY_Greek_finalsmallsigma)
+      else if (symbol == IBUS_KEY_Greek_finalsmallsigma)
+        xupper = IBUS_KEY_Greek_SIGMA;
+      else if (symbol >= IBUS_KEY_Greek_alpha && symbol <= IBUS_KEY_Greek_omega)
         xupper -= (IBUS_KEY_Greek_alpha - IBUS_KEY_Greek_ALPHA);
       break;
     }


### PR DESCRIPTION
A fix for the same bug was recently committed to libx11: https://gitlab.freedesktop.org/xorg/lib/libx11/commit/7f46a38139f66fda734f3a6c445b84ea89c8f310