### PR TITLE
src: Use WAYLAND_DISPLAY on Wayland sessions to make up IBus socket name

### DIFF
--- a/src/ibusshare.c
+++ b/src/ibusshare.c
@@ -100,6 +100,7 @@ ibus_get_socket_path (void)
         gchar *display;
         gchar *displaynumber = "0";
         /* gchar *screennumber = "0"; */
+        gboolean is_wayland = FALSE;
         gchar *p;
 
         path = g_strdup (g_getenv ("IBUS_ADDRESS_FILE"));
@@ -108,13 +109,19 @@ ibus_get_socket_path (void)
         }
 
         if (_display == NULL) {
-            display = g_strdup (g_getenv ("DISPLAY"));
+            display = g_strdup (g_getenv ("WAYLAND_DISPLAY"));
+            if (display)
+                is_wayland = TRUE;
+            else
+                display = g_strdup (g_getenv ("DISPLAY"));
         }
         else {
             display = g_strdup (_display);
         }
 
-        if (display) {
+        if (is_wayland) {
+            displaynumber = display;
+        } else if (display) {
             p = display;
             hostname = display;
             for (; *p != ':' && *p != '\0'; p++);


### PR DESCRIPTION
In Wayland sessions, GNOME Shell 3.36 is leveraging 2 X11 Display
connections so one is used to set up all services for a "X11 session"
before user applications connected to the other display might require it.
This allows seamlessly starting Xwayland on demand to X11 user applications.

IBus here belongs to the first described connection, it is started
explicitly on that display by GNOME Shell as it is necessary to set up
ibus-x11 before any other X11 client might want to use it.

However the use of this "secondary" display results in IBus daemon left
unable to talk to applications, as the socket name is dependent on the
DISPLAY envvar and ibus/applications don't agree on its content.

For wayland sessions, make it look for WAYLAND_DISPLAY, as that'll have
the similar "per session bus" behavior that this seems to look after.

Related: https://gitlab.gnome.org/GNOME/gnome-shell/issues/2341