### PR TITLE
client/gtk2: Remove glib_check_version() in gtk immodule

### DIFF
--- a/client/gtk2/ibusim.c
+++ b/client/gtk2/ibusim.c
@@ -41,9 +41,7 @@ static const GtkIMContextInfo *info_list[] = {
 G_MODULE_EXPORT const gchar*
 g_module_check_init (GModule *module)
 {
-    return glib_check_version (GLIB_MAJOR_VERSION,
-                               GLIB_MINOR_VERSION,
-                               0);
+    return null;
 }
 
 G_MODULE_EXPORT void


### PR DESCRIPTION
In the gtk2/gtk3 immodule, glib_check_version() is being used to make sure
that the installed glib version is not older than the glib version which ibus
is built with.

But there is no reason why glib version is checked in runtime. Library
compatibility is already being checked more precisely by packaging systems and
linkers.

This version check can break the ibus gtk immodule when used with an older but
compatible version of glib, such as glib 2.62.x which is compatible with
2.64.x.

BUG=https://github.com/ibus/ibus/issues/2200