### PR TITLE
Skip parsing of compose sequence with invalid keysyms.

### DIFF
--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -216,8 +216,12 @@ parse_compose_sequence (IBusComposeData *compose_data,
             compose_data->sequence[n] = codepoint;
         }
 
-        if (codepoint == IBUS_KEY_VoidSymbol)
-            g_warning ("Could not get code point of keysym %s", match);
+        if (codepoint == IBUS_KEY_VoidSymbol) {
+            g_warning ("Could not get code point of keysym %s: %s",
+                       match, line);
+            g_free (match);
+            goto fail;
+        }
         g_free (match);
         n++;
     }


### PR DESCRIPTION
Instead of continuing with the keysym defaulted to `<Delete>`, print a
warning and skip the broken XCompose rule entirely. Fixes a bug where
an ~/.XCompose file with a error breaks the delete key.

Tested locally with the example from launchpad bug below:

	   <\> <)> : "☭" # HAMMER AND SICKLE

This is incorrect syntax as neither `<\>` nor `<)>` are correct keysym
names. Before this patch, ibus-daemon -v prints a warning, but
pressing delete twice produces ☭ instead of its normal function. After
this patch, ibus-daemon -v prints a slightly better warning, and the
delete key is unaffected.

BUG=https://github.com/ibus/ibus/issues/2130
BUG=https://bugs.launchpad.net/ubuntu/+source/ibus/+bug/1849399