### PR TITLE
ui/gtk3: Tell Pango about the engine language in the candidate panel

### DIFF
--- a/ui/gtk3/candidatearea.vala
+++ b/ui/gtk3/candidatearea.vala
@@ -32,6 +32,8 @@ class CandidateArea : Gtk.Box {
     private bool m_show_cursor;
     private ThemedRGBA m_rgba;
 
+    private Pango.Attribute m_language_attribute;
+
     private const string LABELS[] = {
         "1.", "2.", "3.", "4.", "5.", "6.", "7.", "8.",
         "9.", "0.", "a.", "b.", "c.", "d.", "e.", "f."
@@ -102,6 +104,10 @@ class CandidateArea : Gtk.Box {
             m_labels[i].set_text(LABELS[i]);
     }
 
+    public void set_language(Pango.Attribute language_attribute) {
+        m_language_attribute = language_attribute.copy();
+    }
+
     public void set_candidates(IBus.Text[] candidates,
                                uint focus_candidate = 0,
                                bool show_cursor = true) {
@@ -115,6 +121,7 @@ class CandidateArea : Gtk.Box {
             bool visible = false;
             if (i < candidates.length) {
                 Pango.AttrList attrs = get_pango_attr_list_from_ibus_text(candidates[i]);
+                attrs.change(m_language_attribute.copy());
                 if (i == focus_candidate && show_cursor) {
                     Pango.Attribute pango_attr = Pango.attr_foreground_new(
                             (uint16)(m_rgba.selected_fg.red * uint16.MAX),

--- a/ui/gtk3/candidatepanel.vala
+++ b/ui/gtk3/candidatepanel.vala
@@ -34,6 +34,8 @@ public class CandidatePanel : Gtk.Box{
 
     private Gdk.Rectangle m_cursor_location;
 
+    private Pango.Attribute m_language_attribute;
+
     public signal void cursor_up();
     public signal void cursor_down();
     public signal void page_up();
@@ -112,8 +114,14 @@ public class CandidatePanel : Gtk.Box{
         m_candidate_area.set_labels(labels);
     }
 
+    public void set_language(Pango.Attribute language_attribute) {
+        m_candidate_area.set_language(language_attribute);
+        m_language_attribute = language_attribute.copy();
+    }
+
     private void set_attributes(Gtk.Label label, IBus.Text text) {
         Pango.AttrList attrs = get_pango_attr_list_from_ibus_text(text);
+        attrs.change(m_language_attribute.copy());
 
         Gtk.StyleContext context = label.get_style_context();
         Gdk.RGBA color;
@@ -154,6 +162,7 @@ public class CandidatePanel : Gtk.Box{
         if (text != null) {
             m_aux_label.set_text(text.get_text());
             Pango.AttrList attrs = get_pango_attr_list_from_ibus_text(text);
+            attrs.change(m_language_attribute.copy());
             m_aux_label.set_attributes(attrs);
             m_aux_label.show();
         } else {

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -822,6 +822,8 @@ class Panel : IBus.PanelService {
         if (!m_use_system_keyboard_layout)
             m_xkblayout.set_layout(engine);
 
+        m_candidate_panel.set_language(new Pango.AttrLanguage(Pango.Language.from_string(engine.get_language())));
+
         engine_contexts_insert(engine);
     }
 


### PR DESCRIPTION
This helps Pango select the correct font variants for the engine language, which is especially important between languages based on han characters which have wildly different forms of the same character.