### PR TITLE
Fix a buffer overflow in compose handling

### DIFF
--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -428,6 +428,8 @@ ibus_compose_data_compare (gpointer a,
 
         if (code_a != code_b)
             return code_a - code_b;
+        if (code_a == 0 && code_b == 0)
+            return 0;
     }
     return 0;
 }


### PR DESCRIPTION
I believe this has no security impact as the XCompose parser is operating on specifically user-configured data, but it *is* making my valgrind sad.

Thanks to Omni for the help in finding the root cause of this.

Test case (a full repro with hacks to get valgrind on the
ibus-engine-simple process is available at
https://github.com/lf-/ibus/tree/repro):

~/.XCompose is:
```
<Multi_key> <g> <h> : "η"
<Multi_key> <g> <v> <t> <h> : "ϑ"
<Multi_key> <g> <h>	: "ɣ"
```

Errors (from include-directive branch before applying this patch):

```
Invalid read of size 4
   at 0x48A6378: ibus_compose_data_compare (ibuscomposetable.c:509)
   by 0x4B64A38: ??? (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x4B649DE: ??? (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x48A8485: ibus_compose_table_new_with_file (ibuscomposetable.c:1108)
   by 0x48A871E: ibus_compose_table_list_add_file (ibuscomposetable.c:1204)
   by 0x48C087A: ibus_engine_simple_add_compose_file (ibusenginesimple.c:1863)
   by 0x48C0A8D: ibus_engine_simple_add_table_by_locale (ibusenginesimple.c:1788)
   by 0x109404: __lambda6_ (main.c:230)
   by 0x1094DE: ___lambda6__gsource_func (main.c:280)
   by 0x4B75A83: g_main_context_dispatch (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x4BC99B0: ??? (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x4B74FD2: g_main_loop_run (in /usr/lib/libglib-2.0.so.0.6600.4)
 Address 0x52926b0 is 0 bytes after a block of size 16 alloc'd
   at 0x483CD7B: realloc (vg_replace_malloc.c:834)
   by 0x4B748F8: g_realloc (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x48A72BA: parse_compose_sequence (ibuscomposetable.c:208)
   by 0x48A77F2: parse_compose_line (ibuscomposetable.c:344)
   by 0x48A79CF: ibus_compose_list_parse_file (ibuscomposetable.c:392)
   by 0x48A79E1: ibus_compose_list_parse_file (ibuscomposetable.c:394)
   by 0x48A83EE: ibus_compose_table_new_with_file (ibuscomposetable.c:1098)
   by 0x48A871E: ibus_compose_table_list_add_file (ibuscomposetable.c:1204)
   by 0x48C087A: ibus_engine_simple_add_compose_file (ibusenginesimple.c:1863)
   by 0x48C0A8D: ibus_engine_simple_add_table_by_locale (ibusenginesimple.c:1788)
   by 0x109404: __lambda6_ (main.c:230)
   by 0x1094DE: ___lambda6__gsource_func (main.c:280)

Invalid read of size 4
   at 0x48A637D: ibus_compose_data_compare (ibuscomposetable.c:510)
   by 0x4B64A38: ??? (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x4B649DE: ??? (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x48A8485: ibus_compose_table_new_with_file (ibuscomposetable.c:1108)
   by 0x48A871E: ibus_compose_table_list_add_file (ibuscomposetable.c:1204)
   by 0x48C087A: ibus_engine_simple_add_compose_file (ibusenginesimple.c:1863)
   by 0x48C0A8D: ibus_engine_simple_add_table_by_locale (ibusenginesimple.c:1788)
   by 0x109404: __lambda6_ (main.c:230)
   by 0x1094DE: ___lambda6__gsource_func (main.c:280)
   by 0x4B75A83: g_main_context_dispatch (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x4BC99B0: ??? (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x4B74FD2: g_main_loop_run (in /usr/lib/libglib-2.0.so.0.6600.4)
 Address 0x534a860 is 0 bytes after a block of size 16 alloc'd
   at 0x483CD7B: realloc (vg_replace_malloc.c:834)
   by 0x4B748F8: g_realloc (in /usr/lib/libglib-2.0.so.0.6600.4)
   by 0x48A72BA: parse_compose_sequence (ibuscomposetable.c:208)
   by 0x48A77F2: parse_compose_line (ibuscomposetable.c:344)
   by 0x48A79CF: ibus_compose_list_parse_file (ibuscomposetable.c:392)
   by 0x48A83EE: ibus_compose_table_new_with_file (ibuscomposetable.c:1098)
   by 0x48A871E: ibus_compose_table_list_add_file (ibuscomposetable.c:1204)
   by 0x48C087A: ibus_engine_simple_add_compose_file (ibusenginesimple.c:1863)
   by 0x48C0A8D: ibus_engine_simple_add_table_by_locale (ibusenginesimple.c:1788)
   by 0x109404: __lambda6_ (main.c:230)
   by 0x1094DE: ___lambda6__gsource_func (main.c:280)
   by 0x4B75A83: g_main_context_dispatch (in /usr/lib/libglib-2.0.so.0.6600.4)
```