### PR TITLE
client/x11: Add support for XFixes ClientDisconnectMode

### DIFF
--- a/client/x11/Makefile.am
+++ b/client/x11/Makefile.am
@@ -49,11 +49,13 @@ ibus_x11_LDADD = \
 	$(libibus) \
 	@X11_LIBS@ \
 	$(GTK_LIBS) \
+	$(XFIXES_LIBS) \
 	$(NULL)
 
 ibus_x11_CFLAGS = \
 	@X11_CFLAGS@ \
 	$(GTK_CFLAGS) \
+	$(XFIXES_CFLAGS) \
 	@DBUS_CFLAGS@ \
 	-I$(top_srcdir)/util/IMdkit \
 	-I$(top_srcdir)/src \

--- a/client/x11/main.c
+++ b/client/x11/main.c
@@ -24,10 +24,15 @@
  */
 #define _GNU_SOURCE
 
+#include "config.h"
+
 #include <X11/Xproto.h>
 #include <X11/Xlib.h>
 #include <X11/keysym.h>
 #include <X11/Xutil.h>
+#ifdef HAVE_XFIXES
+#include <X11/extensions/Xfixes.h>
+#endif
 #include <XimProto.h>
 #include <IMdkit.h>
 #include <Xi18n.h>
@@ -1161,6 +1166,11 @@ main (int argc, char **argv)
     gtk_init (&argc, &argv);
     XSetErrorHandler (_xerror_handler);
     XSetIOErrorHandler (_xerror_io_handler);
+
+#ifdef HAVE_XFIXES
+    XFixesSetClientDisconnectMode(GDK_DISPLAY_XDISPLAY (gdk_display_get_default ()),
+                                  XFixesClientDisconnectFlagTerminate);
+#endif
 
     while (1) {
         static struct option long_options [] = {

--- a/configure.ac
+++ b/configure.ac
@@ -618,6 +618,12 @@ PKG_CHECK_MODULES(XTEST,
 )
 AM_CONDITIONAL([ENABLE_XTEST], [test x"$enable_xtest" = x"yes"])
 
+PKG_CHECK_MODULES(XFIXES,
+    [x11 xfixes >= 6],
+    AC_DEFINE([HAVE_XFIXES], [1], [Define to enable XFixes]),
+    []
+)
+
 # --enable-install-tests
 AC_ARG_ENABLE(install-tests,
     AS_HELP_STRING([--enable-install-tests],


### PR DESCRIPTION
The Xserver itself is capable of terminating itself once all X11 clients
are gone, yet in a typical full session, there are a number of X11
clients such as ibus-x11 running continuously.

Those always-running clients will prevent the Xserver from terminating,
because the actual number of X11 clients will never drop to 0.

Use XFixes ClientDisconnectMode to inform the X11 server that it can
terminate even if ibus-x11 is still running.

That will allow Xwayland from terminating automatically when regular
clients have quit.

On plain Xorg servers, the lifetime of the session is usually tied to
the session manager or window manager, and this change will have no
effect.

Requires:

* xorgproto: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/merge_requests/33
* libXfixes: https://gitlab.freedesktop.org/xorg/lib/libxfixes/-/merge_requests/1
* xserver: https://gitlab.freedesktop.org/xorg/xserver/-/merge_requests/631

See also:

* https://gitlab.gnome.org/GNOME/gnome-settings-daemon/-/merge_requests/228
* https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/1794

IMPORTANT: This is a work in progress, the changes in XFixes are not released yet, this is posted just as a preview of what is coming. Please do not merge this (yet!).