### PR TITLE
setup: Start ibus-daemon with the --daemonize option

### DIFF
--- a/setup/main.py
+++ b/setup/main.py
@@ -528,7 +528,7 @@ class Setup(object):
         GLib.timeout_add_seconds(timeout, lambda *args: main_loop.quit())
         self.__bus.connect("connected", lambda *args: main_loop.quit())
 
-        os.spawnlp(os.P_NOWAIT, "ibus-daemon", "ibus-daemon", "--xim")
+        os.spawnlp(os.P_NOWAIT, "ibus-daemon", "ibus-daemon", "--xim", "--daemonize")
 
         main_loop.run()
 


### PR DESCRIPTION
When starting ibus-daemon from IBus Preferences, it's started
with the command "ibus-daemon --xim". However, ibus-daemon is
killed once you close IBus Preferences.

This commit adds the "--daemonize" option, so ibus-daemon keeps
running also after IBus Preferences has been closed.

BUG=https://github.com/ibus/ibus/issues/2316