### PR TITLE
Add functionality to change IBus panel themes with available GTK themes

### DIFF
--- a/data/dconf/org.freedesktop.ibus.gschema.xml
+++ b/data/dconf/org.freedesktop.ibus.gschema.xml
@@ -210,6 +210,26 @@
       <summary>Custom font</summary>
       <description>Custom font name for language panel</description>
     </key>
+    <key name="use-custom-theme" type="b">
+      <default>false</default>
+      <summary>Use custom theme</summary>
+      <description>Use custom theme name for language panel</description>
+    </key>
+    <key name="custom-theme" type="s">
+      <default>'Adwaita'</default>
+      <summary>Custom theme</summary>
+      <description>Custom theme name for language panel</description>
+    </key>
+    <key name="use-custom-icon" type="b">
+      <default>false</default>
+      <summary>Use custom icon</summary>
+      <description>Use custom icon name for language panel</description>
+    </key>
+    <key name="custom-icon" type="s">
+      <default>'Adwaita'</default>
+      <summary>Custom icon</summary>
+      <description>Custom icon name for language panel</description>
+    </key>
     <key name="use-glyph-from-engine-lang" type="b">
       <default>true</default>
       <summary>Choose glyphs with input method's language on candidate window</summary>

--- a/setup/main.py
+++ b/setup/main.py
@@ -672,18 +672,12 @@ class Setup(object):
         gtk_theme_path = []
         for path in path_list:
             gtk_theme_path.extend(glob.glob(path + "/*/gtk-*/gtk.css"))
-            gtk_theme_path.extend(glob.glob(path + "/*/gtk-*/gtk-dark.css"))
         for path in gtk_theme_path:
-            filename = os.path.basename(path)
-            appendix = ""
-            if filename == "gtk-dark.css":
-                appendix = ":dark"
             theme_name_list.append(os.path.basename(
-                os.path.dirname(os.path.dirname(path))) + appendix)
+                os.path.dirname(os.path.dirname(path))))
 
         theme_name_list.extend([
-            'Adwaita', 'Adwaita:dark',
-            'HighContrast', 'HighContrastInverse'
+            'Adwaita', 'HighContrast', 'HighContrastInverse'
         ])
         theme_name_list = list(set(theme_name_list))
         theme_name_list.sort()

--- a/setup/setup.ui
+++ b/setup/setup.ui
@@ -55,6 +55,18 @@
       </row>
     </data>
   </object>
+  <object class="GtkListStore" id="model_custom_theme">
+    <columns>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="model_custom_icon">
+    <columns>
+      <!-- column-name gchararray -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkAdjustment" id="adjustment_emoji_partial_match">
     <property name="value">3.0</property>
     <property name="lower">1.0</property>
@@ -1318,13 +1330,96 @@
                             <property name="position">0</property>
                           </packing>
                         </child>
+                        <child>
+                          <object class="GtkGrid" id="table3">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="column_spacing">12</property>
+                            <property name="row_spacing">6</property>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_custom_theme">
+                                <property name="label" translatable="yes">Use custom theme:</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="halign">start</property>
+                                <property name="draw_indicator">True</property>
+                                <property name="hexpand">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combobox_custom_theme">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">model_custom_theme</property>
+                                <property name="hexpand">True</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="renderer4"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkCheckButton" id="checkbutton_custom_icon">
+                                <property name="label" translatable="yes">Use custom icon:</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_action_appearance">False</property>
+                                <property name="use_underline">True</property>
+                                <property name="halign">start</property>
+                                <property name="draw_indicator">True</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combobox_custom_icon">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">model_custom_icon</property>
+                                <child>
+                                  <object class="GtkCellRendererText" id="renderer5"/>
+                                  <attributes>
+                                    <attribute name="text">0</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="top_attach">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
                       </object>
                     </child>
                     <child type="label">
                       <object class="GtkLabel" id="label20">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;Fonts&lt;/b&gt;</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Font and Theme&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
                     </child>

--- a/setup/setup.ui
+++ b/setup/setup.ui
@@ -1339,6 +1339,7 @@
                             <child>
                               <object class="GtkCheckButton" id="checkbutton_custom_theme">
                                 <property name="label" translatable="yes">Use custom theme:</property>
+                                <property name="tooltip_text" translatable="yes">Choose a theme of the candidate window</property>
                                 <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
@@ -1375,6 +1376,7 @@
                             <child>
                               <object class="GtkCheckButton" id="checkbutton_custom_icon">
                                 <property name="label" translatable="yes">Use custom icon:</property>
+                                <property name="tooltip_text" translatable="yes">Choose a theme of the arrow buttons on the candidate window</property>
                                 <property name="use_action_appearance">False</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>

--- a/ui/gtk3/bindingcommon.vala
+++ b/ui/gtk3/bindingcommon.vala
@@ -212,4 +212,50 @@ class BindingCommon {
                 css_provider,
                 Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
     }
+
+    public static void
+    set_custom_theme(GLib.Settings? settings_panel) {
+        if (settings_panel == null)
+            return;
+
+        bool use_custom_theme = settings_panel.get_boolean("use-custom-theme");
+        string custom_theme = settings_panel.get_string("custom-theme");
+
+        Gtk.Settings gtk_settings = Gtk.Settings.get_default();
+
+        if (use_custom_theme == false)
+            custom_theme = "";
+
+        if (custom_theme == null || custom_theme == "") {
+            gtk_settings.reset_property("gtk-theme-name");
+            gtk_settings.reset_property("gtk-application-prefer-dark-theme");
+        } else {
+            string[] custom_theme_splitted = custom_theme.split(":");
+            gtk_settings.gtk_theme_name = custom_theme_splitted[0];
+            if (custom_theme_splitted.length == 2 &&
+            custom_theme_splitted[1] == "dark")
+                gtk_settings.gtk_application_prefer_dark_theme = true;
+            else
+                gtk_settings.gtk_application_prefer_dark_theme = false;
+        }
+    }
+
+    public static void
+    set_custom_icon(GLib.Settings? settings_panel) {
+        if (settings_panel == null)
+            return;
+
+        bool use_custom_icon = settings_panel.get_boolean("use-custom-icon");
+        string custom_icon = settings_panel.get_string("custom-icon");
+
+        Gtk.Settings gtk_settings = Gtk.Settings.get_default();
+
+        if (use_custom_icon == false)
+            custom_icon = "";
+
+        if (custom_icon == null || custom_icon == "")
+            gtk_settings.reset_property("gtk-icon-theme-name");
+        else
+            gtk_settings.gtk_icon_theme_name = custom_icon;
+    }
 }

--- a/ui/gtk3/bindingcommon.vala
+++ b/ui/gtk3/bindingcommon.vala
@@ -226,18 +226,10 @@ class BindingCommon {
         if (use_custom_theme == false)
             custom_theme = "";
 
-        if (custom_theme == null || custom_theme == "") {
+        if (custom_theme == null || custom_theme == "")
             gtk_settings.reset_property("gtk-theme-name");
-            gtk_settings.reset_property("gtk-application-prefer-dark-theme");
-        } else {
-            string[] custom_theme_splitted = custom_theme.split(":");
-            gtk_settings.gtk_theme_name = custom_theme_splitted[0];
-            if (custom_theme_splitted.length == 2 &&
-            custom_theme_splitted[1] == "dark")
-                gtk_settings.gtk_application_prefer_dark_theme = true;
-            else
-                gtk_settings.gtk_application_prefer_dark_theme = false;
-        }
+        else
+            gtk_settings.gtk_theme_name = custom_theme;
     }
 
     public static void

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -211,6 +211,22 @@ class Panel : IBus.PanelService {
                                               ref m_css_provider);
         });
 
+        m_settings_panel.changed["custom-theme"].connect((key) => {
+                BindingCommon.set_custom_theme(m_settings_panel);
+        });
+
+        m_settings_panel.changed["use-custom-theme"].connect((key) => {
+                BindingCommon.set_custom_theme(m_settings_panel);
+        });
+
+        m_settings_panel.changed["custom-icon"].connect((key) => {
+                BindingCommon.set_custom_icon(m_settings_panel);
+        });
+
+        m_settings_panel.changed["use-custom-icon"].connect((key) => {
+                BindingCommon.set_custom_icon(m_settings_panel);
+        });
+
         m_settings_panel.changed["use-glyph-from-engine-lang"].connect((key) =>
         {
                 m_use_engine_lang = m_settings_panel.get_boolean(
@@ -816,6 +832,8 @@ class Panel : IBus.PanelService {
         BindingCommon.set_custom_font(m_settings_panel,
                                       null,
                                       ref m_css_provider);
+        BindingCommon.set_custom_theme(m_settings_panel);
+        BindingCommon.set_custom_icon(m_settings_panel);
         set_show_icon_on_systray();
         set_lookup_table_orientation();
         set_show_property_panel();

--- a/ui/gtk3/panelbinding.vala
+++ b/ui/gtk3/panelbinding.vala
@@ -270,6 +270,22 @@ class PanelBinding : IBus.PanelService {
                                               ref m_css_provider);
         });
 
+        m_settings_panel.changed["custom-theme"].connect((key) => {
+                BindingCommon.set_custom_theme(m_settings_panel);
+        });
+
+        m_settings_panel.changed["use-custom-theme"].connect((key) => {
+                BindingCommon.set_custom_theme(m_settings_panel);
+        });
+
+        m_settings_panel.changed["custom-icon"].connect((key) => {
+                BindingCommon.set_custom_icon(m_settings_panel);
+        });
+
+        m_settings_panel.changed["use-custom-icon"].connect((key) => {
+                BindingCommon.set_custom_icon(m_settings_panel);
+        });
+
         m_settings_emoji.changed["unicode-hotkey"].connect((key) => {
                 set_emoji_hotkey();
         });
@@ -422,6 +438,8 @@ class PanelBinding : IBus.PanelService {
         BindingCommon.set_custom_font(m_settings_panel,
                                       m_settings_emoji,
                                       ref m_css_provider);
+        BindingCommon.set_custom_theme(m_settings_panel);
+        BindingCommon.set_custom_icon(m_settings_panel);
         set_emoji_favorites();
         if (m_load_emoji_at_startup && !m_loaded_emoji)
             set_emoji_lang();


### PR DESCRIPTION
The senario of using custom theme or icon is pretty much alike the using custom font. If users want to change IBus panel theme, just tick the `Use custom theme`, then select a theme from the combo box. Or tick the `Use custom icon`, then select an icon theme from the combo box to customize page switch buttons (the arrows):

## Examples
1.
![image](https://user-images.githubusercontent.com/43995067/138550763-6a719f98-2d24-4224-b886-37b0bf0b4d0d.png)
![image](https://user-images.githubusercontent.com/43995067/125318007-097b9800-e36c-11eb-8fc8-dbddbecc513d.png)

2.
![image](https://user-images.githubusercontent.com/43995067/138550794-f02c9d7d-2937-4ec2-a00d-e071a521c40c.png)
![image](https://user-images.githubusercontent.com/43995067/125318197-392aa000-e36c-11eb-8892-5e5e20bd4cad.png)

3.
![image](https://user-images.githubusercontent.com/43995067/138550877-3b690a9a-d304-4e22-95db-f591e728e89f.png)
![image](https://user-images.githubusercontent.com/43995067/138550928-972ee8b7-3a40-4a53-b6e7-dac4884a8275.png)

Untick the box to follow the system global gtk theme or icon theme again.

(This feature is a part of [my goal in GSoC 2021 project](https://summerofcode.withgoogle.com/archive/2021/projects/6295506795364352/), I used to use `GTK_THEME=? ibus-daemon -r &` to change IBus GTK themes with my [IBus-Theme-Tools](https://github.com/openSUSE/IBus-Theme-Tools#non-gnome-desktop), but now I guess it's better to add this functionality to upstream since it's more intuitive.)

@hillwoodroc @qiangzhao @epico