### PR TITLE
client/gtk2/ibusimcontext: Fix wrong cursor location in gtk3 apps

### DIFF
--- a/client/gtk2/ibusimcontext.c
+++ b/client/gtk2/ibusimcontext.c
@@ -1497,7 +1497,10 @@ _set_cursor_location_internal (IBusIMContext *ibusimcontext)
 
 #if GTK_CHECK_VERSION (3, 98, 4)
 #elif GTK_CHECK_VERSION (2, 91, 0)
-    area.y += gdk_window_get_height (ibusimcontext->client_window);
+    if (area.x == -1 && area.y == -1 && area.width == 0 && area.height == 0) {
+        area.x = 0;
+        area.y += gdk_window_get_height (ibusimcontext->client_window);
+    }
 #else
     if (area.x == -1 && area.y == -1 && area.width == 0 && area.height == 0) {
         gint w, h;


### PR DESCRIPTION
It seems in <https://github.com/ibus/ibus/commit/a823161768c8f6916dbdebe73842a9fc04521369> that some condition checking was removed by mistake when setting cursor location for GTK3, which makes the candidate panel always out of focused window. This commit fixed it.

Fixes <https://github.com/ibus/ibus/issues/2337>.

Plus I don't really understand the meaning of those code, but it does fix problem for me. So please review my commit and tell me whether I am right.

I think `area.x = 0; area.y += gdk_window_get_height (ibusimcontext->client_window);` should only be called when a program cannot report a valid cursor location, and then we put candidate panel to the bottom-left corner as a workaround, so it should not be used for most GTK3 programs.