### PR TITLE
man: Update Emoji shortcut key

### DIFF
--- a/ui/gtk3/ibus-emoji.7.in
+++ b/ui/gtk3/ibus-emoji.7.in
@@ -51,7 +51,7 @@ E.g. "Noto Color Emoji", "Android Emoji" font.
 
 .SH "KEYBOARD OPERATIONS"
 .TP
-\fBControl-Shift-e\fR
+\fBControl-Period\fR
 Launch IBus Emojier. The shortcut key can be customized by
 .B ibus\-setup (1).
 .TP


### PR DESCRIPTION
The default Emoji shortcut key was changed in https://github.com/ibus/ibus/commit/b952d30a1b7c741052c168fe1081ecb4d4b1c034 but not updated in the `ibus-emoji.7` man page.