### PR TITLE
Fix unref problems with floating references

### DIFF
--- a/src/ibusinputcontext.c
+++ b/src/ibusinputcontext.c
@@ -550,7 +550,8 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
         g_signal_emit (context, context_signals[COMMIT_TEXT], 0, text);
 
         if (g_object_is_floating (text))
-            g_object_unref (text);
+            g_object_ref_sink (text);
+        g_object_unref (text);
         return;
     }
     if (g_strcmp0 (signal_name, "UpdatePreeditText") == 0) {
@@ -569,7 +570,8 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
                        visible);
 
         if (g_object_is_floating (text))
-            g_object_unref (text);
+            g_object_ref_sink (text);
+        g_object_unref (text);
         return;
     }
     if (g_strcmp0 (signal_name, "UpdatePreeditTextWithMode") == 0) {
@@ -591,7 +593,8 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
                        mode);
 
         if (g_object_is_floating (text))
-            g_object_unref (text);
+            g_object_ref_sink (text);
+        g_object_unref (text);
         return;
     }
 
@@ -619,7 +622,8 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
                        text,
                        visible);
         if (g_object_is_floating (text))
-            g_object_unref (text);
+            g_object_ref_sink (text);
+        g_object_unref (text);
         return;
     }
 
@@ -637,7 +641,8 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
                        table,
                        visible);
         if (g_object_is_floating (table))
-            g_object_unref (table);
+            g_object_ref_sink (table);
+        g_object_unref (table);
         return;
 
     }
@@ -655,7 +660,8 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
                        prop_list);
 
         if (g_object_is_floating (prop_list))
-            g_object_unref (prop_list);
+            g_object_ref_sink (prop_list);
+        g_object_unref (prop_list);
         return;
     }
 
@@ -668,7 +674,8 @@ ibus_input_context_g_signal (GDBusProxy  *proxy,
         g_signal_emit (context, context_signals[UPDATE_PROPERTY], 0, prop);
 
         if (g_object_is_floating (prop))
-            g_object_unref (prop);
+            g_object_ref_sink (prop);
+        g_object_unref (prop);
         return;
     }
 

--- a/src/ibusproperty.c
+++ b/src/ibusproperty.c
@@ -336,17 +336,20 @@ ibus_property_destroy (IBusProperty *prop)
     prop->priv->icon = NULL;
 
     if (prop->priv->label) {
-        g_object_unref (prop->priv->label);
+        if (!ibus_text_get_is_static (prop->priv->label))
+            g_object_unref (prop->priv->label);
         prop->priv->label = NULL;
     }
 
     if (prop->priv->symbol) {
-        g_object_unref (prop->priv->symbol);
+        if (!ibus_text_get_is_static (prop->priv->symbol))
+            g_object_unref (prop->priv->symbol);
         prop->priv->symbol = NULL;
     }
 
     if (prop->priv->tooltip) {
-        g_object_unref (prop->priv->tooltip);
+        if (!ibus_text_get_is_static (prop->priv->tooltip))
+            g_object_unref (prop->priv->tooltip);
         prop->priv->tooltip = NULL;
     }
 
@@ -401,7 +404,7 @@ ibus_property_deserialize (IBusProperty *prop,
     g_variant_get_child (variant, retval++, "u", &prop->priv->type);
 
     GVariant *subvar = g_variant_get_child_value (variant, retval++);
-    if (prop->priv->label != NULL) {
+    if (prop->priv->label && !ibus_text_get_is_static (prop->priv->label)) {
         g_object_unref (prop->priv->label);
     }
     prop->priv->label = IBUS_TEXT (ibus_serializable_deserialize (subvar));
@@ -411,7 +414,7 @@ ibus_property_deserialize (IBusProperty *prop,
     ibus_g_variant_get_child_string (variant, retval++, &prop->priv->icon);
 
     subvar = g_variant_get_child_value (variant, retval++);
-    if (prop->priv->tooltip != NULL) {
+    if (prop->priv->tooltip && !ibus_text_get_is_static (prop->priv->tooltip)) {
         g_object_unref (prop->priv->tooltip);
     }
     prop->priv->tooltip = IBUS_TEXT (ibus_serializable_deserialize (subvar));
@@ -432,7 +435,7 @@ ibus_property_deserialize (IBusProperty *prop,
 
     /* Keep the serialized order for the compatibility when add new members. */
     subvar = g_variant_get_child_value (variant, retval++);
-    if (prop->priv->symbol != NULL) {
+    if (prop->priv->symbol && !ibus_text_get_is_static (prop->priv->symbol)) {
         g_object_unref (prop->priv->symbol);
     }
     prop->priv->symbol = IBUS_TEXT (ibus_serializable_deserialize (subvar));
@@ -564,7 +567,7 @@ ibus_property_set_label (IBusProperty *prop,
     g_assert (IBUS_IS_PROPERTY (prop));
     g_return_if_fail (label == NULL || IBUS_IS_TEXT (label));
 
-    if (prop->priv->label) {
+    if (prop->priv->label && !ibus_text_get_is_static (prop->priv->label)) {
         g_object_unref (prop->priv->label);
     }
 
@@ -583,7 +586,7 @@ ibus_property_set_symbol (IBusProperty *prop,
     g_assert (IBUS_IS_PROPERTY (prop));
     g_return_if_fail (symbol == NULL || IBUS_IS_TEXT (symbol));
 
-    if (prop->priv->symbol) {
+    if (prop->priv->symbol && !ibus_text_get_is_static (prop->priv->symbol)) {
         g_object_unref (prop->priv->symbol);
     }
 
@@ -612,19 +615,16 @@ ibus_property_set_tooltip (IBusProperty *prop,
     g_assert (IBUS_IS_PROPERTY (prop));
     g_assert (tooltip == NULL || IBUS_IS_TEXT (tooltip));
 
-    IBusPropertyPrivate *priv = prop->priv;
-
-    if (priv->tooltip) {
-        g_object_unref (priv->tooltip);
+    if (prop->priv->tooltip && !ibus_text_get_is_static (prop->priv->tooltip)) {
+        g_object_unref (prop->priv->tooltip);
     }
 
     if (tooltip == NULL) {
-        priv->tooltip = ibus_text_new_from_static_string ("");
-        g_object_ref_sink (priv->tooltip);
+        prop->priv->tooltip = ibus_text_new_from_static_string ("");
     }
     else {
-        priv->tooltip = tooltip;
-        g_object_ref_sink (priv->tooltip);
+        prop->priv->tooltip = tooltip;
+        g_object_ref_sink (prop->priv->tooltip);
     }
 }
 


### PR DESCRIPTION
While trying to get a test client to work, I encountered some problems that this PR fixes. My test client uses `ibusimcontext.c` from the GTK client and the problems showed when I ran it with debug-enabled GLIB libraries.

When running with debug-enabled GLIB there are several critical errors output: "A floating object ... was finalized. This means
that someone called g_object_unref() on an object that had only a floating reference; the initial floating reference is not
owned by anyone and must be removed with g_object_ref_sink()."

This change fixes this by calling `g_object_ref_sink()` before `g_object_unref()` if we have a floating reference.

It also fixes another related problem where we called `g_object_unref()` on a static IBusText string (created with
`ibus_text_new_from_static_string()`) for which the API documentation says not to free.