### PR TITLE
src/ibuscomposetable: invalidate cache based on symlink mtime too

### DIFF
--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -1040,9 +1040,13 @@ ibus_compose_table_load_cache (const gchar *compose_file)
         if (!g_file_test (path, G_FILE_TEST_EXISTS))
             break;
 
-        if (g_stat (compose_file, &original_buf))
-            break;
         if (g_stat (path, &cache_buf))
+            break;
+        if (g_lstat (compose_file, &original_buf))
+            break;
+        if (original_buf.st_mtime > cache_buf.st_mtime)
+            break;
+        if (g_stat (compose_file, &original_buf))
             break;
         if (original_buf.st_mtime > cache_buf.st_mtime)
             break;


### PR DESCRIPTION
When the compose file is a symbolic link, take the link itself's modification time into account (in addition to its target's) in determining whether to invalidate the compose cache.

This is useful e.g. on NixOS systems where the compose file might point to a store path with an irrelevant modification time, and we want the cache to expire when the symlink itself changes.

This mirrors a merge request in gtk (https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/4163) since there seems to be some duplicated logic between here and there.

I've tested this and confirmed that it works.