### PR TITLE
src, client/x11: Add systemd unit file

### DIFF
--- a/client/x11/10-ibus-x11.in
+++ b/client/x11/10-ibus-x11.in
@@ -1,0 +1,2 @@
+#!/bin/sh
+@libexecdir@/ibus-x11 &

--- a/client/x11/Makefile.am
+++ b/client/x11/Makefile.am
@@ -67,6 +67,16 @@ noinst_HEADERS = \
 	locales.h \
 	$(NULL)
 
+xwaylandsessiond_in_files = 10-ibus-x11.in
+xwaylandsessiond_DATA = $(xwaylandsessiond_in_files:.in=)
+xwaylandsessionddir=$(sysconfdir)/xdg/Xwayland-session.d
+
+10-ibus-x11: 10-ibus-x11.in
+	$(AM_V_GEN) sed -e "s|\@libexecdir\@|$(libexecdir)|"  $< > $@.tmp && mv $@.tmp $@
+
+install-data-hook:
+	chmod 755 $(DESTDIR)$(xwaylandsessionddir)/10-ibus-x11
+
 $(libIMdkit):
 	(cd $(top_builddir)/util/IMdkit; make)
 
@@ -80,5 +90,13 @@ locales.h:
 		uniq | sort | \
 		xargs python -c 'import sys;print "#define LOCALES_STRING \"%s\"" % ",".join(sys.argv[1:])' \
 	 ) > $@
+
+CLEANFILES =                    \
+    $(xwaylandsessiond_DATA)    \
+    $(NULL)
+
+EXTRA_DIST =                    \
+    10-ibus-x11.in              \
+    $(NULL)
 
 -include $(top_srcdir)/git.mk

--- a/configure.ac
+++ b/configure.ac
@@ -393,6 +393,22 @@ if test x"$enable_dconf" = x"yes"; then
     enable_dconf="yes (enabled, use --disable-dconf to disable)"
 fi
 
+AC_ARG_ENABLE(systemd-services,
+    AS_HELP_STRING([--disable-systemd-services],
+                   [Disable systemd services installation]),
+    [enable_systemd=$enableval],
+    [enable_systemd=yes]
+)
+AM_CONDITIONAL([ENABLE_SYSTEMD], [test x"$enable_systemd" = x"yes"])
+
+if test x"$enable_systemd" = x"yes"; then
+    PKG_CHECK_MODULES(SYSTEMD, [
+        systemd >= 0.7.5
+    ])
+    AC_SUBST([SYSTEMD_USER_UNIT_DIR], [`$PKG_CONFIG --variable systemduserunitdir systemd`])
+    enable_systemd="yes (enabled, use --disable-systemd-services to disable)"
+fi
+
 # Check env.
 AC_PATH_PROG(ENV_IBUS_TEST, env)
 AC_SUBST(ENV_IBUS_TEST)
@@ -860,6 +876,7 @@ Build options:
   UCD directory                 $UCD_DIR
   Socket directory              "$IBUS_SOCKET_DIR"
   XFixes client disconnect      $have_xfixes
+  Install systemd service       $enable_systemd
   Run test cases                $enable_tests
   Install tests                 $enable_install_tests
 ])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -317,6 +317,11 @@ install-data-hook:
 	        rm "$(DESTDIR)$(dictdir)/$$file" || exit $$?; \
 	    fi; \
 	done
+	$(MKDIR_P) "$(DESTDIR)$(SYSTEMD_USER_UNIT_DIR)/gnome-session.target.wants/"
+	( \
+		cd "$(DESTDIR)$(SYSTEMD_USER_UNIT_DIR)/gnome-session.target.wants" ; \
+		$(LN_S) -f "../org.freedesktop.IBus.session.GNOME.service" .; \
+	)
 
 emoji_parser_SOURCES =          \
     emoji-parser.c              \
@@ -383,7 +388,17 @@ clean-local:
 	$(NULL)
 endif
 
+if ENABLE_SYSTEMD
+systemdservice_in_files = org.freedesktop.IBus.session.GNOME.service.in
+systemdservice_DATA = $(systemdservice_in_files:.service.in=.service)
+systemdservicedir=$(SYSTEMD_USER_UNIT_DIR)
+
+org.freedesktop.IBus.session.GNOME.service: org.freedesktop.IBus.session.GNOME.service.in
+	$(AM_V_GEN) sed -e "s|\@bindir\@|$(bindir)|"  $< > $@.tmp && mv $@.tmp $@
+endif
+
 EXTRA_DIST =                    \
+    org.freedesktop.IBus.session.GNOME.service.in \
     emoji-parser.c              \
     ibusversion.h.in            \
     ibusmarshalers.list         \
@@ -393,6 +408,7 @@ EXTRA_DIST =                    \
     $(NULL)
 
 CLEANFILES +=                   \
+    $(systemdservice_DATA)      \
     $(BUILT_SOURCES)            \
     stamp-ibusmarshalers.h      \
     stamp-ibusenumtypes.h       \

--- a/src/org.freedesktop.IBus.session.GNOME.service.in
+++ b/src/org.freedesktop.IBus.session.GNOME.service.in
@@ -1,0 +1,28 @@
+[Unit]
+Description=IBus Daemon
+CollectMode=inactive-or-failed
+
+# Require GNOME session and specify startup ordering
+Requisite=gnome-session-initialized.target
+After=gnome-session-initialized.target
+PartOf=gnome-session-initialized.target
+Before=gnome-session.target
+
+# Needs to run when DISPLAY/WAYLAND_DISPLAY is set
+After=gnome-session-initialized.target
+PartOf=gnome-session-initialized.target
+
+# Never run in GDM
+Conflicts=gnome-session@gnome-login.target
+
+[Service]
+Type=dbus
+# Only pull --xim in X11 session, it is done via Xwayland-session.d on Wayland
+ExecStart=sh -c '@bindir@/ibus-daemon --panel disable $([[ $XDG_SESSION_TYPE == "x11" ]] && echo "--xim")'
+Restart=on-abnormal
+BusName=org.freedesktop.IBus
+TimeoutStopSec=5
+Slice=session.slice
+
+[Install]
+WantedBy=gnome-session.target


### PR DESCRIPTION
This so far depends on GNOME targets, and is thus just usable there.
Other DEs wishing to use systemd and ibus will need to add the
necessary dependencies where applicable.

There are 2 scenarios here:
- On X11 sessions, ibus-daemon will be launched with --xim parameter,
  so ibus-x11 is started with it.
- On Wayland sessions, ibus-daemon will be started without XIM support,
  ibus-x11 will be launched and tear down together with all other
  session X11 services while Xwayland is running.

For the second part of the second situation, additionally install
a script at /etc/xdg/Xwayland-session.d, which takes care of X11
service initialization together with the Xwayland instance.