### PR TITLE
Use our own prefix to look up systemd user services dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -405,7 +405,7 @@ if test x"$enable_systemd" = x"yes"; then
     PKG_CHECK_MODULES(SYSTEMD, [
         systemd >= 0.7.5
     ])
-    AC_SUBST([SYSTEMD_USER_UNIT_DIR], [`$PKG_CONFIG --variable systemduserunitdir systemd`])
+    AC_SUBST([SYSTEMD_USER_UNIT_DIR], [`$PKG_CONFIG --define-variable prefix='${prefix}' --variable systemduserunitdir systemd`])
     enable_systemd="yes (enabled, use --disable-systemd-services to disable)"
 fi
 


### PR DESCRIPTION
Fixes the build on NixOS.

See https://www.bassi.io/articles/2018/03/15/pkg-config-and-paths/ and the discussion at https://github.com/NixOS/nixpkgs/pull/164105#discussion_r826011775.