### PR TITLE
bus/services: Fix bashisms in org.freedesktop.IBus.session.GNOME.service

### DIFF
--- a/bus/services/org.freedesktop.IBus.session.GNOME.service.in
+++ b/bus/services/org.freedesktop.IBus.session.GNOME.service.in
@@ -18,7 +18,7 @@ Conflicts=gnome-session@gnome-login.target
 [Service]
 Type=dbus
 # Only pull --xim in X11 session, it is done via Xwayland-session.d on Wayland
-ExecStart=sh -c '@bindir@/ibus-daemon --panel disable $([[ $XDG_SESSION_TYPE == "x11" ]] && echo "--xim")'
+ExecStart=sh -c '@bindir@/ibus-daemon --panel disable $([ "$XDG_SESSION_TYPE" = "x11" ] && echo "--xim")'
 Restart=on-abnormal
 BusName=org.freedesktop.IBus
 TimeoutStopSec=5


### PR DESCRIPTION
The "[[ ... ]]" is bash's compound command not in POSIX sh. This style
is problematic in Xorg session in environments where sh is not bash,
suach as Debian and Ubuntu.

BUG=https://github.com/ibus/ibus/issues/2397