### PR TITLE
enable emoji extension for (Fedora) liveuser

### DIFF
--- a/bus/main.c
+++ b/bus/main.c
@@ -53,8 +53,7 @@ static gchar *desktop = "gnome";
 
 static gchar *panel_extension_disable_users[] = {
     "gdm",
-    "gnome-initial-setup",
-    "liveuser"
+    "gnome-initial-setup"
 };
 
 static void


### PR DESCRIPTION
Emoji should work just fine in Fedora Live instances as it does for Ubuntu live images.
Fedora Live even has zswap enabled now so it is even less prone to ram issues.

Downstream Fedora [bug](https://bugzilla.redhat.com/show_bug.cgi?id=1625596) from 2018, which has more details