### PR TITLE
data/dconf: Revert Emoji shoftcut key to Super-space

### DIFF
--- a/data/dconf/org.freedesktop.ibus.gschema.xml
+++ b/data/dconf/org.freedesktop.ibus.gschema.xml
@@ -248,7 +248,7 @@
       <description>The shortcut keys for turning Unicode typing on or off</description>
     </key>
     <key name="hotkey" type="as">
-      <default>[ '&lt;Control&gt;period', '&lt;Control&gt;semicolon' ]</default>
+      <default>[ '&lt;Super&gt;period' ]</default>
       <summary>Emoji shortcut keys for gtk_accelerator_parse</summary>
       <description>The shortcut keys for turning emoji typing on or off</description>
     </key>


### PR DESCRIPTION
IBus provides the D-Bus method to override IBus emoji UI and i think
Super-period is better than Ctrl-period for the emoji shortcut key to
compare MS-Window, Macintosh. IBus emoji UI connects to the input method
and provides the language emoji annotations.

Seems moving GTK Cotrol-period to gnome-shell Suer-period is difficult
at present.

BUG=https://github.com/ibus/ibus/issues/2390
BUG=https://gitlab.gnome.org/GNOME/gnome-shell/-/issues/5728