### PR TITLE
Only force surrounding text on for Firefox

### DIFF
--- a/client/gtk2/ibusimcontext.c
+++ b/client/gtk2/ibusimcontext.c
@@ -576,12 +576,17 @@ _request_surrounding_text (IBusIMContext *context)
         g_signal_emit (context, _signal_retrieve_surrounding_id, 0,
                        &return_value);
         if (!return_value) {
-            /* #2054 firefox::IMContextWrapper::GetCurrentParagraph() could
-             * fail with the first typing on firefox but it succeeds with
-             * the second typing.
-             */
-            g_warning ("%s has no capability of surrounding-text feature",
-                       g_get_prgname ());
+            if (strcmp(g_get_prgname(), "firefox")) {
+                context->caps &= ~IBUS_CAP_SURROUNDING_TEXT;
+                ibus_input_context_set_capabilities(context->ibuscontext, context->caps);
+            } else {
+                /* #2054 firefox::IMContextWrapper::GetCurrentParagraph() could
+                * fail with the first typing on firefox but it succeeds with
+                * the second typing, so don't disable surrounding text.
+                */
+                g_warning("%s has no capability of surrounding-text feature",
+                        g_get_prgname());
+            }
         }
     }
 }


### PR DESCRIPTION
Currently IBUS_CAP_SURROUNDING_TEXT is a compile-time flag which tells whether or not ibus can deal with surrounding text. However, ibus supporting surrounding text is only half of what's needed because the application (e.g. Chrome) also needs to support surrounding text. Currently ibus engines have no way to detect if the application supports surrounding text because the capability is always set.

See #2354 for a scenario that is affected by this behavior: the user types 'n', the engine outputs 'n'. Next the user types ';', the end result should be the 'n' replaced by 'ŋ'.
If the application supports surrounding text (e.g. gedit) the engine can use `ibus_engine_delete_surrounding_text()` to delete ';'.
However, if the application doesn't support surrounding text (e.g. Chrome, gnome-terminal) then the engine has to use `ibus_engine_forward_key_event()` to send a backspace to delete the previous character. Which means the engine needs a way to detect whether or not the application supports surrounding text.

An example where this behavior can be seen is in ibus-engine-keyman with the [IPA (SIL)](https://keyman.com/keyboards/sil_ipa) keyboard.

It turns out that before commit 7b3b8c8 the IBUS_CAP_SURROUNDING_TEXT capability could be used to detect if the application supports surrounding text. The changes in commit 7b3b8c8 modified the behavior so that instead of removing the IBUS_CAP_SURROUNDING_TEXT capability if the `retrieve-surrounding` signal returns 0 a warning is output. This works around a bug in Firefox where the first call sometimes failed but subsequent calls work (#2054). However, because the IBUS_CAP_SURROUNDING_TEXT now is always set it breaks backspace in apps that don't support surrounding text. This can be seen e.g in Chrome/Chromium as well as in gnome-terminal. When using the _IPA (SIL)_ keyboard, backspace won't work: switch to _IPA (SIL)_ keyboard, type a few characters then type backspace. Notice that this does nothing in Chrome/Chromium and gnome-terminal. See #2354 for more examples where things fail.

This change limits the workaround for #2054 to Firefox which keeps compatibility with the previous behavior where it's needed while fixing things for apps that do not support surrounding text.

Related bugs:
- #2271
- #2354 
- #2418

BUG=https://github.com/ibus/ibus/issues/2054
BUG=https://github.com/ibus/ibus/issues/2354