### PR TITLE
Fix configure texts for surrounding text

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -602,14 +602,13 @@ AC_SUBST(IBUS_ICON_KEYBOARD)
 # --disable-surrounding-text option.
 AC_ARG_ENABLE(surrounding-text,
     AS_HELP_STRING([--disable-surrounding-text],
-        [Enable surrounding-text support]),
+        [Disable surrounding-text support]),
     [enable_surrounding_text=$enableval],
     [enable_surrounding_text=yes]
 )
 if test x"$enable_surrounding_text" = x"yes"; then
     AC_DEFINE(ENABLE_SURROUNDING, TRUE, [Enable surrounding-text support])
-else
-    enable_surrounding_text="no (disabled, use --enable-surrounding-text to enable)"
+    enable_surrounding_text="yes (enabled, use --disable-surrounding-text to disable)"
 fi
 
 # --disable-ui


### PR DESCRIPTION
The options and corresponding texts for surrounding-text were mixed up. This change makes them consistent with the text for other options.

## Output of `./configure`

### Before this change

```
  ...
  Panel icon                    "ibus-keyboard"
  Enable surrounding-text       yes
  Enable libnotify              yes (enabled, use --disable-libnotify to disable)
  ...
```

### With this change

```
  ...
  Panel icon                    "ibus-keyboard"
  Enable surrounding-text       yes (enabled, use --disable-surrounding-text to disable)
  Enable libnotify              yes (enabled, use --disable-libnotify to disable)
  ...
```

## Output of `./configure --disable-surrounding-text --disable-libnotify`

### Before this change

```
  ...
  Panel icon                    "ibus-keyboard"
  Enable surrounding-text       no (disabled, use --enable-surrounding-text to enable)
  Enable libnotify              no
  ...
```

### With this change

```
  ...
  Panel icon                    "ibus-keyboard"
  Enable surrounding-text       no
  Enable libnotify              no
  ...
```

## Output of `./configure --help`

### Before this change

```
  ...
  --disable-key-snooper   Always disable key snooper in gtk im module
  --disable-surrounding-text
                          Enable surrounding-text support
  --disable-ui            Disable ibus default user interface
  ...
```

### With this change

```
  ...
  --disable-key-snooper   Always disable key snooper in gtk im module
  --disable-surrounding-text
                          Disable surrounding-text support
  --disable-ui            Disable ibus default user interface
  ...
```