### PR TITLE
Add prefilter flag

### DIFF
--- a/bus/ibusimpl.c
+++ b/bus/ibusimpl.c
@@ -575,10 +575,17 @@ bus_ibus_impl_init (BusIBusImpl *ibus)
     g_object_ref_sink (ibus->fake_context);
     bus_dbus_impl_register_object (BUS_DEFAULT_DBUS,
                                    (IBusService *) ibus->fake_context);
-    bus_input_context_set_capabilities (ibus->fake_context,
-                                        IBUS_CAP_PREEDIT_TEXT |
-                                        IBUS_CAP_FOCUS |
-                                        IBUS_CAP_SURROUNDING_TEXT);
+
+    guint capabilities = IBUS_CAP_PREEDIT_TEXT | IBUS_CAP_FOCUS;
+
+#ifdef ENABLE_SURROUNDING
+    capabilities |= IBUS_CAP_SURROUNDING_TEXT;
+#endif
+#ifdef ENABLE_PREFILTER
+    capabilities |= IBUS_CAP_PREFILTER;
+#endif
+
+    bus_input_context_set_capabilities(ibus->fake_context, capabilities);
     g_signal_connect (ibus->fake_context,
                       "engine-changed",
                       G_CALLBACK (_context_engine_changed_cb),

--- a/client/gtk2/ibusimcontext.c
+++ b/client/gtk2/ibusimcontext.c
@@ -1024,6 +1024,11 @@ ibus_im_context_init (GObject *obj)
 #else
     ibusimcontext->caps = IBUS_CAP_PREEDIT_TEXT | IBUS_CAP_FOCUS;
 #endif
+
+#ifdef ENABLE_PREFILTER
+    ibusimcontext->caps |= IBUS_CAP_PREFILTER;
+#endif
+
     if (_use_sync_mode == 1)
         ibusimcontext->caps |= IBUS_CAP_SYNC_PROCESS_KEY_V2;
 

--- a/client/gtk2/ibusimcontext.c
+++ b/client/gtk2/ibusimcontext.c
@@ -422,10 +422,11 @@ _process_key_event_done (GObject      *object,
                 gdk_event_get_device (event),
                 gdk_event_get_time (event),
                 gdk_key_event_get_keycode (event),
-                gdk_event_get_modifier_state (event) | IBUS_IGNORED_MASK,
+                (gdk_event_get_modifier_state (event) | IBUS_IGNORED_MASK) & ~IBUS_PREFILTER_MASK,
                 0);
 #else
         ((GdkEventKey *)event)->state |= IBUS_IGNORED_MASK;
+        ((GdkEventKey *)event)->state &= ~IBUS_PREFILTER_MASK;
         gdk_event_put (event);
 #endif
     }
@@ -682,8 +683,10 @@ _key_snooper_cb (GtkWidget   *widget,
     if (G_UNLIKELY (event->state & IBUS_HANDLED_MASK))
         return TRUE;
 
-    if (G_UNLIKELY (event->state & IBUS_IGNORED_MASK))
-        return FALSE;
+    if (!(event->state & IBUS_PREFILTER_MASK)) {
+        if (G_UNLIKELY(event->state & IBUS_IGNORED_MASK))
+            return FALSE;
+    }
 
     do {
         if (_fake_context != ibuscontext)
@@ -1179,7 +1182,7 @@ ibus_im_context_filter_keypress (GtkIMContext *context,
         GdkModifierType state = gdk_event_get_modifier_state (event);
         if (state & IBUS_HANDLED_MASK)
             return TRUE;
-        if (state & IBUS_IGNORED_MASK)
+        if (state & IBUS_IGNORED_MASK && !(state & IBUS_PREFILTER_MASK))
             return ibus_im_context_commit_event (ibusimcontext, event);
     }
 #else
@@ -1189,7 +1192,7 @@ ibus_im_context_filter_keypress (GtkIMContext *context,
     /* Do not call gtk_im_context_filter_keypress() because
      * gtk_im_context_simple_filter_keypress() binds Ctrl-Shift-u
      */
-    if (event->state & IBUS_IGNORED_MASK)
+    if (event->state & IBUS_IGNORED_MASK && !(event->state & IBUS_PREFILTER_MASK))
         return ibus_im_context_commit_event (ibusimcontext, event);
 
     /* XXX it is a workaround for some applications do not set client

--- a/client/wayland/main.c
+++ b/client/wayland/main.c
@@ -593,17 +593,17 @@ _create_input_context_done (GObject      *object,
         g_signal_connect (wlim->ibuscontext, "hide-preedit-text",
                           G_CALLBACK (_context_hide_preedit_text_cb),
                           wlim);
-    
+
+        guint capabilities = IBUS_CAP_PREEDIT_TEXT | IBUS_CAP_FOCUS;
+
 #ifdef ENABLE_SURROUNDING
-        ibus_input_context_set_capabilities (wlim->ibuscontext,
-                                             IBUS_CAP_FOCUS |
-                                             IBUS_CAP_PREEDIT_TEXT |
-                                             IBUS_CAP_SURROUNDING_TEXT);
-#else
-        ibus_input_context_set_capabilities (wlim->ibuscontext,
-                                             IBUS_CAP_FOCUS |
-                                             IBUS_CAP_PREEDIT_TEXT);
+        capabilities |= IBUS_CAP_SURROUNDING_TEXT;
 #endif
+#ifdef ENABLE_PREFILTER
+        capabilities |= IBUS_CAP_PREFILTER;
+#endif
+        ibus_input_context_set_capabilities(wlim->ibuscontext,
+                                            capabilities);
 
         ibus_input_context_focus_in (wlim->ibuscontext);
     }

--- a/configure.ac
+++ b/configure.ac
@@ -612,6 +612,18 @@ else
     enable_surrounding_text="no (disabled, use --enable-surrounding-text to enable)"
 fi
 
+# --disable-prefilter option
+AC_ARG_ENABLE(prefilter,
+    AS_HELP_STRING([--disable-prefilter],
+        [Disable prefilter support]),
+    [enable_prefilter=$enableval],
+    [enable_prefilter=yes]
+)
+if test x"$enable_prefilter" = x"yes"; then
+    AC_DEFINE(ENABLE_PREFILTER, TRUE, [Enable prefilter support])
+    enable_prefilter="yes (enabled, use --disable-prefilter to disable)"
+fi
+
 # --disable-ui
 AC_ARG_ENABLE(ui,
     AS_HELP_STRING([--disable-ui],
@@ -890,6 +902,7 @@ Build options:
   No snooper regexes            "$NO_SNOOPER_APPS"
   Panel icon                    "$IBUS_ICON_KEYBOARD"
   Enable surrounding-text       $enable_surrounding_text
+  Enable prefilter              $enable_prefilter
   Enable libnotify              $enable_libnotify
   Enable Emoji dict             $enable_emoji_dict
   Unicode Emoji directory       $UNICODE_EMOJI_DIR

--- a/src/ibustypes.h
+++ b/src/ibustypes.h
@@ -53,6 +53,7 @@
  * @IBUS_BUTTON3_MASK: Mouse button 3 (right) is activated.
  * @IBUS_BUTTON4_MASK: Mouse button 4 (scroll up) is activated.
  * @IBUS_BUTTON5_MASK: Mouse button 5 (scroll down) is activated.
+ * @IBUS_PREFILTER_MASK: Prefilter mask indicates the event has been prefiltered by the engine.
  * @IBUS_HANDLED_MASK: Handled mask indicates the event has been handled by ibus.
  * @IBUS_FORWARD_MASK: Forward mask indicates the event has been forward from ibus.
  * @IBUS_IGNORED_MASK: It is an alias of IBUS_FORWARD_MASK.
@@ -63,7 +64,7 @@
  * @IBUS_MODIFIER_MASK: Modifier mask for the all the masks above.
  *
  * Handles key modifier such as control, shift and alt and release event.
- * Note that nits 15 - 25 are currently unused, while bit 29 is used internally.
+ * Note that bits 15 - 22 are currently unused, while bit 29 is used internally.
  */
 typedef enum
 {
@@ -82,10 +83,11 @@ typedef enum
     IBUS_BUTTON5_MASK  = 1 << 12,
 
     /* The next few modifiers are used by XKB, so we skip to the end.
-     * Bits 15 - 23 are currently unused. Bit 29 is used internally.
+     * Bits 15 - 22 are currently unused. Bit 29 is used internally.
      */
 
     /* ibus mask */
+    IBUS_PREFILTER_MASK= 1 << 23,
     IBUS_HANDLED_MASK  = 1 << 24,
     IBUS_FORWARD_MASK  = 1 << 25,
     IBUS_IGNORED_MASK  = IBUS_FORWARD_MASK,
@@ -96,7 +98,7 @@ typedef enum
 
     IBUS_RELEASE_MASK  = 1 << 30,
 
-    IBUS_MODIFIER_MASK = 0x5f001fff
+    IBUS_MODIFIER_MASK = 0x5f801fff
 } IBusModifierType;
 
 /**

--- a/src/ibustypes.h
+++ b/src/ibustypes.h
@@ -114,19 +114,22 @@ typedef enum
  * @IBUS_CAP_SYNC_PROCESS_KEY: Asynchronous process key events are not
  *  supported and the ibus_engine_forward_key_event() should not be
  *  used for the return value of #IBusEngine::process_key_event().
+ * @IBUS_CAP_PREFILTER: ibus is compiled with prefilter support.
  *
  * Capability flags of UI.
  */
-typedef enum {
-    IBUS_CAP_PREEDIT_TEXT       = 1 << 0,
-    IBUS_CAP_AUXILIARY_TEXT     = 1 << 1,
-    IBUS_CAP_LOOKUP_TABLE       = 1 << 2,
-    IBUS_CAP_FOCUS              = 1 << 3,
-    IBUS_CAP_PROPERTY           = 1 << 4,
-    IBUS_CAP_SURROUNDING_TEXT   = 1 << 5,
-    IBUS_CAP_OSK                = 1 << 6,
-    IBUS_CAP_SYNC_PROCESS_KEY   = 1 << 7,
+typedef enum
+{
+    IBUS_CAP_PREEDIT_TEXT = 1 << 0,
+    IBUS_CAP_AUXILIARY_TEXT = 1 << 1,
+    IBUS_CAP_LOOKUP_TABLE = 1 << 2,
+    IBUS_CAP_FOCUS = 1 << 3,
+    IBUS_CAP_PROPERTY = 1 << 4,
+    IBUS_CAP_SURROUNDING_TEXT = 1 << 5,
+    IBUS_CAP_OSK = 1 << 6,
+    IBUS_CAP_SYNC_PROCESS_KEY = 1 << 7,
     IBUS_CAP_SYNC_PROCESS_KEY_V2 = IBUS_CAP_SYNC_PROCESS_KEY,
+    IBUS_CAP_PREFILTER = 1 << 8,
 } IBusCapabilite;
 
 /**


### PR DESCRIPTION
This PR adds a new `IBUS_PREFILTER_MASK` flag which the engine can set on the state. This allows engines to prefilter events and use that to control the order of the output even if some syntethic key events get interspersed between the input.

A scenario where this is necessary is in [ibus-engine-keyman](https://github.com/keymanapp/keyman) for applications that don't support surrounding text like Chrome/Chromium and gnome-terminal. For example with the [_IPA (SIL)_](https://keyman.com/keyboards/sil_ipa) keyboard, the users presses the `n` key which produces 'n' output. Then the user presses `;`. The expected result is that the 'n' gets replaced by 'ŋ'. For applications that don't support surrounding text, the engine has to forward a Backspace key event followed by committing the new text 'ŋ'. However, since the key event gets processed asynchronously, it can happen that the new text gets committed before the Backspace key is processed, leading to the deletion of 'ŋ' instead of 'n'.

The `IBUS_PREFILTER_MASK` flag allows to solve this problem: when the engine receives a key press, it calls `ibus_engine_forward_key_event()` for the same key with the `IBUS_PREFILTER_MASK` flag set. Only when it receives a key press with the `IBUS_PREFILTER_MASK` already set it will process the key. When it generates the Backspace key event it will forward it to ibus with the `IBUS_PREFILTER_MASK` flag already set. When it comes back to the engine the key events will be in the correct order.

Since `IBUS_PREFILTER_MASK` is a flag that will only ever get set by the engine it shouldn't break any existing engines.

This PR also adds `IBUS_CAP_PREFILTER` to `IBusCapabilite`.  This allows engines to detect whether they are dealing with an ibus version that was compiled with prefilter support.

Fixes #2539.