### PR TITLE
tools: Check libdl for dlclose() properly in configure

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,10 @@ AC_CHECK_HEADERS([sys/prctl.h])
 # Check functions.
 AC_CHECK_FUNCS(daemon)
 
+# Check libraries.
+AC_CHECK_LIB(c, dlclose, LIBDL="", [AC_CHECK_LIB(dl, dlclose, LIBDL="-ldl")])
+AC_SUBST(LIBDL)
+
 # Check packages.
 # Check glib2.
 AM_PATH_GLIB_2_0

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -63,7 +63,7 @@ AM_LDADD = \
     @GTHREAD2_LIBS@ \
     $(libibus) \
     $(libibusimmodule) \
-    -ldl               \
+    $(LIBDL) \
     $(NULL)
 
 AM_VALAFLAGS = \


### PR DESCRIPTION
In commit https://github.com/ibus/ibus/commit/fee26c6b45de307cfdcb1bf9cc75e3df45ee82b2 `-ldl` was added to `LDADD` in `tools/Makefile.am`
but libdl is not available in all systems (especially BSD based systems).
libdl for `dlclose()` should be checked by `configure.ac`.