### PR TITLE
Fix build without libnotify

### DIFF
--- a/ui/gtk3/Makefile.am
+++ b/ui/gtk3/Makefile.am
@@ -92,7 +92,7 @@ AM_LDADD += \
 
 AM_VALAFLAGS += \
        --pkg=libnotify \
-       -D ENABLE_LIBNOTIFY \
+       --define=LIBNOTIFY \
        $(NULL)
 endif
 

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -766,7 +766,7 @@ class Panel : IBus.PanelService {
     private void update_version_1_5_26() {
         var message = _("Keymap changes do not work in Plasma Wayland at " +
                         "present. Please use systemsettings5 instead.");
-#if ENABLE_LIBNOTIFY
+#if LIBNOTIFY
         if (!Notify.is_initted()) {
             Notify.init ("ibus");
         }


### PR DESCRIPTION
If I build with --disable-libnotify I get

"/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: panel.o: in function `panel_load_settings':
panel.c:(.text+0x6906): undefined reference to `notify_is_initted'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: panel.c:(.text+0x6932): undefined reference to `notify_notification_new'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: panel.c:(.text+0x6942): undefined reference to `notify_notification_set_timeout'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: panel.c:(.text+0x6951): undefined reference to `notify_notification_set_category'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: panel.c:(.text+0x6969): undefined reference to `notify_notification_show'
/usr/x86_64-pc-linux-gnu/bin/x86_64-pc-linux-gnu-ld: panel.c:(.text+0x6a6f): undefined reference to `notify_init'"

otherwise. This patches fixes that.