### PR TITLE
Add a new needs-surrounding-text property to engine to tell the clien…

### DIFF
--- a/bus/engineproxy.c
+++ b/bus/engineproxy.c
@@ -60,6 +60,7 @@ struct _BusEngineProxy {
     /* cached properties */
     IBusPropList *prop_list;
     gboolean has_focus_id;
+    gboolean needs_surrounding_text;
 };
 
 struct _BusEngineProxyClass {
@@ -129,6 +130,8 @@ static void     bus_engine_proxy_initable_iface_init
                                                 (GInitableIface
                                                                *initable_iface);
 static void     bus_engine_proxy_get_has_focus_id
+                                                (BusEngineProxy    *engine);
+static void     bus_engine_proxy_get_needs_surrounding_text
                                                 (BusEngineProxy    *engine);
 
 G_DEFINE_TYPE_WITH_CODE (BusEngineProxy, bus_engine_proxy, IBUS_TYPE_PROXY,
@@ -721,9 +724,12 @@ bus_engine_proxy_new_internal (const gchar     *path,
     if (layout != NULL && layout[0] != '\0') {
         engine->keymap = ibus_keymap_get (layout);
     }
-    if (ibus)
-        hash_table = bus_ibus_impl_get_engine_focus_id_table (ibus);
+    if (!ibus)
+        return engine;
+
+    hash_table = bus_ibus_impl_get_engine_focus_id_table (ibus);
     if (hash_table) {
+        EngineFocusCategory category;
         category = (EngineFocusCategory)GPOINTER_TO_INT (
                 g_hash_table_lookup (hash_table,
                                      ibus_engine_desc_get_name (desc)));
@@ -734,6 +740,21 @@ bus_engine_proxy_new_internal (const gchar     *path,
         else
             bus_engine_proxy_get_has_focus_id (engine);
     }
+
+    hash_table = bus_ibus_impl_get_engine_needs_surrounding_text_table (ibus);
+    if (hash_table) {
+        EngineSurroundingTextCategory category;
+        category = (EngineSurroundingTextCategory)GPOINTER_TO_INT (
+                g_hash_table_lookup (hash_table,
+                                     ibus_engine_desc_get_name (desc)));
+        if (category == ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_NEED)
+            engine->needs_surrounding_text = TRUE;
+        else if (category == ENGINE_SURROUNDING_TEXT_CATEGORY_NO_NEED)
+            engine->needs_surrounding_text = FALSE;
+        else
+            bus_engine_proxy_get_needs_surrounding_text (engine);
+    }
+
     return engine;
 }
 
@@ -1264,6 +1285,26 @@ bus_engine_proxy_set_content_type (BusEngineProxy *engine,
 }
 
 static void
+bus_engine_proxy_get_engine_property (BusEngineProxy *engine,
+                                      const gchar    *prop_name,
+                                      GAsyncReadyCallback callback,
+                                      GHashTable *hash_table)
+{
+    g_assert (BUS_IS_ENGINE_PROXY (engine));
+    g_assert (hash_table);
+    g_dbus_proxy_call ((GDBusProxy *) engine,
+                       "org.freedesktop.DBus.Properties.Get",
+                       g_variant_new ("(ss)",
+                                      IBUS_INTERFACE_ENGINE,
+                                      prop_name),
+                       G_DBUS_CALL_FLAGS_NONE,
+                       -1,
+                       NULL,
+                       callback,
+                       g_hash_table_ref (hash_table));
+}
+
+static void
 _get_has_focus_id_cb (GObject        *object,
                       GAsyncResult   *res,
                       gpointer        user_data)
@@ -1299,23 +1340,54 @@ static void
 bus_engine_proxy_get_has_focus_id (BusEngineProxy *engine)
 {
     BusIBusImpl *ibus = BUS_DEFAULT_IBUS;
-    GHashTable *hash_table;
-
-    g_assert (BUS_IS_ENGINE_PROXY (engine));
     g_assert (ibus);
+    bus_engine_proxy_get_engine_property (engine,
+                                          "FocusId",
+                                          _get_has_focus_id_cb,
+                                          bus_ibus_impl_get_engine_focus_id_table (ibus));
+}
 
-    hash_table = bus_ibus_impl_get_engine_focus_id_table (ibus);
-    g_assert (hash_table);
-    g_dbus_proxy_call ((GDBusProxy *) engine,
-                       "org.freedesktop.DBus.Properties.Get",
-                       g_variant_new ("(ss)",
-                                      IBUS_INTERFACE_ENGINE,
-                                      "FocusId"),
-                       G_DBUS_CALL_FLAGS_NONE,
-                       -1,
-                       NULL,
-                       _get_has_focus_id_cb,
-                       g_hash_table_ref (hash_table));
+static void
+_get_needs_surrounding_text_cb (GObject        *object,
+                                GAsyncResult   *res,
+                                gpointer        user_data)
+{
+    GHashTable *hash_table = (GHashTable*)user_data;
+    BusEngineProxy *engine;
+    GError *error = NULL;
+    GVariant *result;
+
+    g_return_if_fail (BUS_IS_ENGINE_PROXY (object));
+    engine = BUS_ENGINE_PROXY (object);
+    result = g_dbus_proxy_call_finish (G_DBUS_PROXY (object), res, &error);
+
+    if (result != NULL) {
+        GVariant *variant = NULL;
+        gpointer value;
+        g_variant_get (result, "(v)", &variant);
+        engine->needs_surrounding_text = g_variant_get_boolean (variant);
+        g_variant_unref (variant);
+        g_variant_unref (result);
+        value =  GINT_TO_POINTER (engine->needs_surrounding_text
+                                  ? ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_NEED
+                                  : ENGINE_SURROUNDING_TEXT_CATEGORY_NO_NEED);
+        g_hash_table_replace (
+            hash_table,
+            (gpointer)ibus_engine_desc_get_name (engine->desc),
+            value);
+    }
+    g_hash_table_unref (hash_table);
+}
+
+static void
+bus_engine_proxy_get_needs_surrounding_text (BusEngineProxy *engine)
+{
+    BusIBusImpl *ibus = BUS_DEFAULT_IBUS;
+    g_assert (ibus);
+    bus_engine_proxy_get_engine_property (engine,
+                                          "NeedsSurroundingText",
+                                          _get_needs_surrounding_text_cb,
+                                          bus_ibus_impl_get_engine_needs_surrounding_text_table (ibus));
 }
 
 /* a macro to generate a function to call a nullary D-Bus method. */
@@ -1348,6 +1420,8 @@ bus_engine_proxy_focus_in (BusEngineProxy *engine,
     if (engine->has_focus)
         return;
     engine->has_focus = TRUE;
+    if (engine->needs_surrounding_text)
+        g_signal_emit (engine, engine_signals[REQUIRE_SURROUNDING_TEXT], 0);
     if (engine->has_focus_id) {
         g_dbus_proxy_call ((GDBusProxy *)engine,
                            "FocusInId",
@@ -1404,6 +1478,8 @@ bus_engine_proxy_enable (BusEngineProxy *engine)
     g_assert (BUS_IS_ENGINE_PROXY (engine));
     if (!engine->enabled) {
         engine->enabled = TRUE;
+        if (engine->needs_surrounding_text)
+            g_signal_emit (engine, engine_signals[REQUIRE_SURROUNDING_TEXT], 0);
         g_dbus_proxy_call ((GDBusProxy *)engine,
                            "Enable",
                            NULL,

--- a/bus/engineproxy.c
+++ b/bus/engineproxy.c
@@ -60,7 +60,7 @@ struct _BusEngineProxy {
     /* cached properties */
     IBusPropList *prop_list;
     gboolean has_focus_id;
-    gboolean active_surrounding_text;
+    gboolean has_active_surrounding_text;
 };
 
 struct _BusEngineProxyClass {
@@ -724,7 +724,7 @@ bus_engine_proxy_new_internal (const gchar     *path,
         engine->keymap = ibus_keymap_get (layout);
     }
 
-    g_return_val_if_fail (ibus, engine)
+    g_return_val_if_fail (ibus, engine);
 
     hash_table = bus_ibus_impl_get_engine_focus_id_table (ibus);
     if (hash_table) {
@@ -1370,7 +1370,7 @@ _get_has_active_surrounding_text_cb (GObject        *object,
         g_variant_unref (result);
         value =  GINT_TO_POINTER (
                                 engine->has_active_surrounding_text
-                                ? ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_ACTIVE
+                                ? ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_ACTIVE:
                                   ENGINE_SURROUNDING_TEXT_CATEGORY_NOT_ACTIVE);
         g_hash_table_replace (
             hash_table,

--- a/bus/engineproxy.c
+++ b/bus/engineproxy.c
@@ -60,7 +60,7 @@ struct _BusEngineProxy {
     /* cached properties */
     IBusPropList *prop_list;
     gboolean has_focus_id;
-    gboolean needs_surrounding_text;
+    gboolean active_surrounding_text;
 };
 
 struct _BusEngineProxyClass {
@@ -131,7 +131,7 @@ static void     bus_engine_proxy_initable_iface_init
                                                                *initable_iface);
 static void     bus_engine_proxy_get_has_focus_id
                                                 (BusEngineProxy    *engine);
-static void     bus_engine_proxy_get_needs_surrounding_text
+static void     bus_engine_proxy_get_active_surrounding_text
                                                 (BusEngineProxy    *engine);
 
 G_DEFINE_TYPE_WITH_CODE (BusEngineProxy, bus_engine_proxy, IBUS_TYPE_PROXY,
@@ -702,7 +702,6 @@ bus_engine_proxy_new_internal (const gchar     *path,
     BusEngineProxy *engine;
     BusIBusImpl *ibus = BUS_DEFAULT_IBUS;
     GHashTable *hash_table = NULL;
-    EngineFocusCategory category = ENGINE_FOCUS_CATEGORY_NONE;
 
     g_assert (path);
     g_assert (IBUS_IS_ENGINE_DESC (desc));
@@ -724,8 +723,8 @@ bus_engine_proxy_new_internal (const gchar     *path,
     if (layout != NULL && layout[0] != '\0') {
         engine->keymap = ibus_keymap_get (layout);
     }
-    if (!ibus)
-        return engine;
+
+    g_return_val_if_fail (ibus, engine)
 
     hash_table = bus_ibus_impl_get_engine_focus_id_table (ibus);
     if (hash_table) {
@@ -741,18 +740,18 @@ bus_engine_proxy_new_internal (const gchar     *path,
             bus_engine_proxy_get_has_focus_id (engine);
     }
 
-    hash_table = bus_ibus_impl_get_engine_needs_surrounding_text_table (ibus);
+    hash_table = bus_ibus_impl_get_engine_active_surrounding_text_table (ibus);
     if (hash_table) {
         EngineSurroundingTextCategory category;
         category = (EngineSurroundingTextCategory)GPOINTER_TO_INT (
                 g_hash_table_lookup (hash_table,
                                      ibus_engine_desc_get_name (desc)));
-        if (category == ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_NEED)
-            engine->needs_surrounding_text = TRUE;
-        else if (category == ENGINE_SURROUNDING_TEXT_CATEGORY_NO_NEED)
-            engine->needs_surrounding_text = FALSE;
+        if (category == ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_ACTIVE)
+            engine->has_active_surrounding_text = TRUE;
+        else if (category == ENGINE_SURROUNDING_TEXT_CATEGORY_NOT_ACTIVE)
+            engine->has_active_surrounding_text = FALSE;
         else
-            bus_engine_proxy_get_needs_surrounding_text (engine);
+            bus_engine_proxy_get_active_surrounding_text (engine);
     }
 
     return engine;
@@ -1285,10 +1284,10 @@ bus_engine_proxy_set_content_type (BusEngineProxy *engine,
 }
 
 static void
-bus_engine_proxy_get_engine_property (BusEngineProxy *engine,
-                                      const gchar    *prop_name,
+bus_engine_proxy_get_engine_property (BusEngineProxy     *engine,
+                                      const gchar        *prop_name,
                                       GAsyncReadyCallback callback,
-                                      GHashTable *hash_table)
+                                      GHashTable         *hash_table)
 {
     g_assert (BUS_IS_ENGINE_PROXY (engine));
     g_assert (hash_table);
@@ -1341,16 +1340,17 @@ bus_engine_proxy_get_has_focus_id (BusEngineProxy *engine)
 {
     BusIBusImpl *ibus = BUS_DEFAULT_IBUS;
     g_assert (ibus);
-    bus_engine_proxy_get_engine_property (engine,
-                                          "FocusId",
-                                          _get_has_focus_id_cb,
-                                          bus_ibus_impl_get_engine_focus_id_table (ibus));
+    bus_engine_proxy_get_engine_property (
+                               engine,
+                               "FocusId",
+                               _get_has_focus_id_cb,
+                               bus_ibus_impl_get_engine_focus_id_table (ibus));
 }
 
 static void
-_get_needs_surrounding_text_cb (GObject        *object,
-                                GAsyncResult   *res,
-                                gpointer        user_data)
+_get_has_active_surrounding_text_cb (GObject        *object,
+                                     GAsyncResult   *res,
+                                     gpointer        user_data)
 {
     GHashTable *hash_table = (GHashTable*)user_data;
     BusEngineProxy *engine;
@@ -1365,12 +1365,13 @@ _get_needs_surrounding_text_cb (GObject        *object,
         GVariant *variant = NULL;
         gpointer value;
         g_variant_get (result, "(v)", &variant);
-        engine->needs_surrounding_text = g_variant_get_boolean (variant);
+        engine->has_active_surrounding_text = g_variant_get_boolean (variant);
         g_variant_unref (variant);
         g_variant_unref (result);
-        value =  GINT_TO_POINTER (engine->needs_surrounding_text
-                                  ? ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_NEED
-                                  : ENGINE_SURROUNDING_TEXT_CATEGORY_NO_NEED);
+        value =  GINT_TO_POINTER (
+                                engine->has_active_surrounding_text
+                                ? ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_ACTIVE
+                                  ENGINE_SURROUNDING_TEXT_CATEGORY_NOT_ACTIVE);
         g_hash_table_replace (
             hash_table,
             (gpointer)ibus_engine_desc_get_name (engine->desc),
@@ -1380,14 +1381,15 @@ _get_needs_surrounding_text_cb (GObject        *object,
 }
 
 static void
-bus_engine_proxy_get_needs_surrounding_text (BusEngineProxy *engine)
+bus_engine_proxy_get_active_surrounding_text (BusEngineProxy *engine)
 {
     BusIBusImpl *ibus = BUS_DEFAULT_IBUS;
     g_assert (ibus);
-    bus_engine_proxy_get_engine_property (engine,
-                                          "NeedsSurroundingText",
-                                          _get_needs_surrounding_text_cb,
-                                          bus_ibus_impl_get_engine_needs_surrounding_text_table (ibus));
+    bus_engine_proxy_get_engine_property (
+               engine,
+               "ActiveSurroundingText",
+               _get_has_active_surrounding_text_cb,
+               bus_ibus_impl_get_engine_active_surrounding_text_table (ibus));
 }
 
 /* a macro to generate a function to call a nullary D-Bus method. */
@@ -1420,7 +1422,7 @@ bus_engine_proxy_focus_in (BusEngineProxy *engine,
     if (engine->has_focus)
         return;
     engine->has_focus = TRUE;
-    if (engine->needs_surrounding_text)
+    if (engine->has_active_surrounding_text)
         g_signal_emit (engine, engine_signals[REQUIRE_SURROUNDING_TEXT], 0);
     if (engine->has_focus_id) {
         g_dbus_proxy_call ((GDBusProxy *)engine,
@@ -1478,7 +1480,7 @@ bus_engine_proxy_enable (BusEngineProxy *engine)
     g_assert (BUS_IS_ENGINE_PROXY (engine));
     if (!engine->enabled) {
         engine->enabled = TRUE;
-        if (engine->needs_surrounding_text)
+        if (engine->has_active_surrounding_text)
             g_signal_emit (engine, engine_signals[REQUIRE_SURROUNDING_TEXT], 0);
         g_dbus_proxy_call ((GDBusProxy *)engine,
                            "Enable",

--- a/bus/ibusimpl.c
+++ b/bus/ibusimpl.c
@@ -73,6 +73,7 @@ struct _BusIBusImpl {
     GHashTable *engine_table;
 
     GHashTable *engine_focus_id_table;
+    GHashTable *engine_needs_surrounding_text_table;
 
     BusInputContext *focused_context;
     BusPanelProxy   *panel;
@@ -599,6 +600,7 @@ bus_ibus_impl_init (BusIBusImpl *ibus)
     ibus->global_engine_name = NULL;
     ibus->global_previous_engine_name = NULL;
     ibus->engine_focus_id_table = g_hash_table_new (g_str_hash, g_str_equal);
+    ibus->engine_needs_surrounding_text_table = g_hash_table_new (g_str_hash, g_str_equal);
 
     /* focus the fake_context, if use_global_engine is enabled. */
     if (ibus->use_global_engine)
@@ -680,6 +682,11 @@ bus_ibus_impl_destroy (BusIBusImpl *ibus)
     }
 
     bus_ibus_impl_registry_destroy (ibus);
+
+    if (ibus->factory_dict != NULL) {
+        g_hash_table_destroy (ibus->engine_needs_surrounding_text_table);
+        ibus->engine_needs_surrounding_text_table = NULL;
+    }
 
     IBUS_OBJECT_CLASS (bus_ibus_impl_parent_class)->destroy (IBUS_OBJECT (ibus));
 }
@@ -2397,3 +2404,11 @@ bus_ibus_impl_get_engine_focus_id_table (BusIBusImpl *ibus)
     return ibus->engine_focus_id_table;
 }
 
+GHashTable *
+bus_ibus_impl_get_engine_needs_surrounding_text_table (BusIBusImpl *ibus)
+{
+
+    g_assert (BUS_IS_IBUS_IMPL (ibus));
+
+    return ibus->engine_needs_surrounding_text_table;
+}

--- a/bus/ibusimpl.c
+++ b/bus/ibusimpl.c
@@ -73,7 +73,7 @@ struct _BusIBusImpl {
     GHashTable *engine_table;
 
     GHashTable *engine_focus_id_table;
-    GHashTable *engine_needs_surrounding_text_table;
+    GHashTable *engine_active_surrounding_text_table;
 
     BusInputContext *focused_context;
     BusPanelProxy   *panel;
@@ -600,7 +600,8 @@ bus_ibus_impl_init (BusIBusImpl *ibus)
     ibus->global_engine_name = NULL;
     ibus->global_previous_engine_name = NULL;
     ibus->engine_focus_id_table = g_hash_table_new (g_str_hash, g_str_equal);
-    ibus->engine_needs_surrounding_text_table = g_hash_table_new (g_str_hash, g_str_equal);
+    ibus->engine_active_surrounding_text_table = g_hash_table_new (g_str_hash,
+                                                                   g_str_equal);
 
     /* focus the fake_context, if use_global_engine is enabled. */
     if (ibus->use_global_engine)
@@ -683,9 +684,9 @@ bus_ibus_impl_destroy (BusIBusImpl *ibus)
 
     bus_ibus_impl_registry_destroy (ibus);
 
-    if (ibus->factory_dict != NULL) {
-        g_hash_table_destroy (ibus->engine_needs_surrounding_text_table);
-        ibus->engine_needs_surrounding_text_table = NULL;
+    if (ibus->engine_active_surrounding_text_table != NULL) {
+        g_hash_table_destroy (ibus->engine_active_surrounding_text_table);
+        ibus->engine_active_surrounding_text_table = NULL;
     }
 
     IBUS_OBJECT_CLASS (bus_ibus_impl_parent_class)->destroy (IBUS_OBJECT (ibus));
@@ -2405,10 +2406,10 @@ bus_ibus_impl_get_engine_focus_id_table (BusIBusImpl *ibus)
 }
 
 GHashTable *
-bus_ibus_impl_get_engine_needs_surrounding_text_table (BusIBusImpl *ibus)
+bus_ibus_impl_get_engine_active_surrounding_text_table (BusIBusImpl *ibus)
 {
 
     g_assert (BUS_IS_IBUS_IMPL (ibus));
 
-    return ibus->engine_needs_surrounding_text_table;
+    return ibus->engine_active_surrounding_text_table;
 }

--- a/bus/ibusimpl.h
+++ b/bus/ibusimpl.h
@@ -66,6 +66,13 @@ typedef enum
     ENGINE_FOCUS_CATEGORY_HAS_ID
 } EngineFocusCategory;
 
+typedef enum
+{
+    ENGINE_SURROUNDING_TEXT_CATEGORY_NONE = 0,
+    ENGINE_SURROUNDING_TEXT_CATEGORY_NO_NEED,
+    ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_NEED
+} EngineSurroundingTextCategory;
+
 GType            bus_ibus_impl_get_type             (void);
 
 /**
@@ -90,6 +97,8 @@ gboolean         bus_ibus_impl_is_embed_preedit_text
 BusInputContext *bus_ibus_impl_get_focused_input_context
                                                     (BusIBusImpl        *ibus);
 GHashTable      *bus_ibus_impl_get_engine_focus_id_table
+                                                    (BusIBusImpl        *ibus);
+GHashTable      *bus_ibus_impl_get_engine_needs_surrounding_text_table
                                                     (BusIBusImpl        *ibus);
 G_END_DECLS
 #endif

--- a/bus/ibusimpl.h
+++ b/bus/ibusimpl.h
@@ -69,8 +69,8 @@ typedef enum
 typedef enum
 {
     ENGINE_SURROUNDING_TEXT_CATEGORY_NONE = 0,
-    ENGINE_SURROUNDING_TEXT_CATEGORY_NO_NEED,
-    ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_NEED
+    ENGINE_SURROUNDING_TEXT_CATEGORY_NOT_ACTIVE,
+    ENGINE_SURROUNDING_TEXT_CATEGORY_HAS_ACTIVE
 } EngineSurroundingTextCategory;
 
 GType            bus_ibus_impl_get_type             (void);
@@ -98,7 +98,7 @@ BusInputContext *bus_ibus_impl_get_focused_input_context
                                                     (BusIBusImpl        *ibus);
 GHashTable      *bus_ibus_impl_get_engine_focus_id_table
                                                     (BusIBusImpl        *ibus);
-GHashTable      *bus_ibus_impl_get_engine_needs_surrounding_text_table
+GHashTable      *bus_ibus_impl_get_engine_active_surrounding_text_table
                                                     (BusIBusImpl        *ibus);
 G_END_DECLS
 #endif

--- a/src/ibusengine.c
+++ b/src/ibusengine.c
@@ -64,6 +64,7 @@ enum {
     PROP_0,
     PROP_ENGINE_NAME,
     PROP_HAS_FOCUS_ID,
+    PROP_NEEDS_SURROUNDING_TEXT,
 };
 
 
@@ -86,6 +87,7 @@ struct _IBusEnginePrivate {
     gboolean               enable_extension;
     gchar                 *current_extension_name;
     gboolean               has_focus_id;
+    gboolean               needs_surrounding_text;
 };
 
 
@@ -303,6 +305,7 @@ static const gchar introspection_xml[] =
     /* FIXME properties */
     "    <property name='ContentType' type='(uu)' access='write' />"
     "    <property name='FocusId' type='(b)' access='read' />"
+    "    <property name='NeedsSurroundingText' type='(b)' access='read' />"
     "  </interface>"
     "</node>";
 
@@ -387,6 +390,21 @@ ibus_engine_class_init (IBusEngineClass *class)
                     g_param_spec_boolean ("has-focus-id",
                         "has focus id",
                         "Has focus ID",
+                        FALSE,
+                        G_PARAM_READWRITE |
+                        G_PARAM_CONSTRUCT_ONLY));
+
+    /**
+     * IBusEngine:needs-surrounding-text:
+     *
+     * Whether the IBusEngine needs to receive updates when surrounding text
+     * changes.
+     */
+    g_object_class_install_property (gobject_class,
+                    PROP_NEEDS_SURROUNDING_TEXT,
+                    g_param_spec_boolean ("needs-surrounding-text",
+                        "engine needs surrounding text updates",
+                        "Set to TRUE if engine needs surrounding text updates",
                         FALSE,
                         G_PARAM_READWRITE |
                         G_PARAM_CONSTRUCT_ONLY));
@@ -988,6 +1006,9 @@ ibus_engine_set_property (IBusEngine   *engine,
     case PROP_HAS_FOCUS_ID:
         engine->priv->has_focus_id = g_value_get_boolean (value);
         break;
+    case PROP_NEEDS_SURROUNDING_TEXT:
+        engine->priv->needs_surrounding_text = g_value_get_boolean (value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (engine, prop_id, pspec);
     }
@@ -1005,6 +1026,9 @@ ibus_engine_get_property (IBusEngine *engine,
         break;
     case PROP_HAS_FOCUS_ID:
         g_value_set_boolean (value, engine->priv->has_focus_id);
+        break;
+    case PROP_NEEDS_SURROUNDING_TEXT:
+        g_value_set_boolean (value, engine->priv->needs_surrounding_text);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (engine, prop_id, pspec);
@@ -1446,6 +1470,23 @@ ibus_engine_service_method_call (IBusService           *service,
 }
 
 /**
+ * _ibus_engine_needs_surrounding_text:
+ *
+ * Implement the "NeedsSurroundingText" method call of the org.freedesktop.IBus interface.
+ */
+static GVariant *
+_ibus_engine_needs_surrounding_text (IBusEngine      *engine,
+                                     GDBusConnection *connection,
+                                     GError         **error)
+{
+    if (error) {
+        *error = NULL;
+    }
+
+    return g_variant_new_boolean (engine->priv->needs_surrounding_text);
+}
+
+/**
  * _ibus_engine_has_focus_id:
  *
  * Implement the "FocusId" method call of the org.freedesktop.IBus interface.
@@ -1479,6 +1520,7 @@ ibus_engine_service_get_property (IBusService        *service,
                                         GError **);
     } methods [] =  {
         { "FocusId",                    _ibus_engine_has_focus_id },
+        {"NeedsSurroundingText",        _ibus_engine_needs_surrounding_text},
     };
 
     if (g_strcmp0 (interface_name, IBUS_INTERFACE_ENGINE) != 0) {


### PR DESCRIPTION
... the IME needs surrounding text updates. That makes calling ibus_engine_get_surrounding_text() in enable(), focus_in(_id)() unnecessary. That property must be set at construct time.

As discussed in https://github.com/ibus/ibus/issues/2423, this pull request implements a new needs-surrounding-text property.
There is probably room for improvement. Let me know what you think about it.
It is modelled after the focus-in-id property.