### PR TITLE
man: Update Emoji shortcut key to Super-Period

### DIFF
--- a/ui/gtk3/ibus-emoji.7.in
+++ b/ui/gtk3/ibus-emoji.7.in
@@ -51,7 +51,7 @@ E.g. "Noto Color Emoji", "Android Emoji" font.
 
 .SH "KEYBOARD OPERATIONS"
 .TP
-\fBControl-Period or Control-Semicolon\fR
+\fBSuper-Period\fR
 Launch IBus Emojier. The shortcut key can be customized by
 .B ibus\-setup (1).
 .TP


### PR DESCRIPTION
The default Emoji shortcut key was changed in https://github.com/ibus/ibus/commit/1520c39d0d6036da725fcecd932883be3f3d3575 but not updated in the `ibus-emoji.7` man page.