### PR TITLE
configure: Use AC_C_BIGENDIAN macro to check endianness.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -152,12 +152,10 @@ AC_CHECK_LIB(c, dlclose, LIBDL="", [AC_CHECK_LIB(dl, dlclose, LIBDL="-ldl")])
 AC_SUBST(LIBDL)
 
 # Check endianness.
-AC_MSG_CHECKING([build system endianness])
 AC_C_BIGENDIAN([ENDIAN=big],[ENDIAN=little],[ENDIAN=unknown],[])
 if test x"$ENDIAN" != xlittle  -a x"$ENDIAN" != xbig; then
     AC_MSG_ERROR([Cannot determine endianness])
 fi
-AC_MSG_RESULT($ENDIAN)
 AC_SUBST(ENDIAN)
 
 # Check packages.

--- a/configure.ac
+++ b/configure.ac
@@ -153,31 +153,9 @@ AC_SUBST(LIBDL)
 
 # Check endianness.
 AC_MSG_CHECKING([build system endianness])
-ENDIAN=unknown
-AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM(
-        [[
-            #include <endian.h>
-            #if __BYTE_ORDER != __LITTLE_ENDIAN
-            #error
-            #endif
-        ]]
-    )],
-    [ENDIAN=little]
-)
-AC_RUN_IFELSE(
-    [AC_LANG_PROGRAM(
-        [[
-            #include <endian.h>
-            #if __BYTE_ORDER != __BIG_ENDIAN
-            #error
-            #endif
-        ]]
-    )],
-    [ENDIAN=big]
-)
+AC_C_BIGENDIAN([ENDIAN=big],[ENDIAN=little],[ENDIAN=unknown],[])
 if test x"$ENDIAN" != xlittle  -a x"$ENDIAN" != xbig; then
-    AC_MSG_ERROR([Cannot deermine endianness without endian.h])
+    AC_MSG_ERROR([Cannot determine endianness])
 fi
 AC_MSG_RESULT($ENDIAN)
 AC_SUBST(ENDIAN)


### PR DESCRIPTION
`__BYTE_ORDER` is Linux specific (NetBSD has `_BYTE_ORDER`) but `AC_C_BIGENDIAN` seems enough.
https://www.gnu.org/software/autoconf/manual/autoconf-2.71/html_node/C-Compiler.html#index-AC_005fC_005fBIGENDIAN-1