### PR TITLE
configure: check and define X11_LOCALEDATADIR to access Compose data.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,6 +349,14 @@ else
 fi
 AC_SUBST(X11_PREFIX)
 
+# Check locale dir for Compose files.
+AC_CHECK_FILE($X11_PREFIX/share/X11/locale/locale.dir,
+              X11_LOCALEDATADIR="$X11_PREFIX/share/X11/locale",
+              [AC_CHECK_FILE($X11_PREFIX/lib/X11/locale/locale.dir,
+               X11_LOCALEDATADIR="$X11_PREFIX/lib/X11/locale",
+               X11_LOCALEDATADIR="$(datadir)/X11/locale")])
+AC_SUBST(X11_LOCALEDATADIR)
+
 if test x"$enable_wayland" = x"yes"; then
     # Check for wayland
     PKG_CHECK_MODULES(WAYLAND, [

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,7 +54,7 @@ AM_CPPFLAGS =                                           \
     -DIBUS_DISABLE_DEPRECATION_WARNINGS                 \
     -DIBUS_COMPILATION                                  \
     -DISOCODES_PREFIX=\"$(ISOCODES_PREFIX)\"            \
-    -DX11_DATA_PREFIX=\"$(X11_PREFIX)\"                 \
+    -DX11_LOCALEDATADIR=\"$(X11_LOCALEDATADIR)\"        \
     $(NULL)
 
 # ibus library

--- a/src/gencomposetable.c
+++ b/src/gencomposetable.c
@@ -28,8 +28,6 @@
 #include "ibuscomposetable.h"
 #include "ibusenginesimpleprivate.h"
 
-#define X11_DATADIR X11_DATA_PREFIX "/share/X11/locale"
-
 
 static void
 save_compose_table_endianness (IBusComposeTableEx *compose_table,
@@ -84,7 +82,7 @@ main (int argc, char *argv[])
     if (!path || !g_file_test (path, G_FILE_TEST_EXISTS)) {
         g_clear_pointer (&path, g_free);
         for (sys_lang = sys_langs; *sys_lang; sys_lang++) {
-            path = g_build_filename (X11_DATADIR, *sys_lang,
+            path = g_build_filename (X11_LOCALEDATADIR, *sys_lang,
                                      "Compose", NULL);
             if (!path)
                 continue;
@@ -93,7 +91,7 @@ main (int argc, char *argv[])
         }
     }
     if (!path) {
-        g_warning ("en_US compose file is not found in %s.", X11_DATADIR);
+        g_warning ("en_US compose file is not found in %s.", X11_LOCALEDATADIR);
         return 1;
     } else {
         g_debug ("Create a cache of %s", path);

--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -39,7 +39,6 @@
 
 #define IBUS_COMPOSE_TABLE_MAGIC "IBusComposeTable"
 #define IBUS_COMPOSE_TABLE_VERSION (4)
-#define X11_DATADIR X11_DATA_PREFIX "/share/X11/locale"
 #define IBUS_MAX_COMPOSE_ALGORITHM_LEN 9
 
 typedef struct {
@@ -285,7 +284,7 @@ expand_include_path (const char *include_path) {
             case 'S': /* system compose dir */
                 o = out;
                 former = g_strndup (head, i - head);
-                out = g_strdup_printf ("%s%s%s", o, former, X11_DATADIR);
+                out = g_strdup_printf ("%s%s%s", o, former, X11_LOCALEDATADIR);
                 head = i + 2;
                 g_free (o);
                 g_free (former);
@@ -397,7 +396,7 @@ get_en_compose_file (void)
     char * const *sys_lang = NULL;
     char *path = NULL;
     for (sys_lang = sys_langs; *sys_lang; sys_lang++) {
-        path = g_build_filename (X11_DATADIR, *sys_lang, "Compose", NULL);
+        path = g_build_filename (X11_LOCALEDATADIR, *sys_lang, "Compose", NULL);
         if (g_file_test (path, G_FILE_TEST_EXISTS))
             break;
         g_clear_pointer (&path, g_free);

--- a/src/ibusenginesimple.c
+++ b/src/ibusenginesimple.c
@@ -37,7 +37,6 @@
 #include <memory.h>
 #include <stdlib.h>
 
-#define X11_DATADIR X11_DATA_PREFIX "/share/X11/locale"
 #define IBUS_ENGINE_SIMPLE_GET_PRIVATE(o)  \
    ((IBusEngineSimplePrivate *)ibus_engine_simple_get_instance_private (o))
 
@@ -1440,7 +1439,7 @@ ibus_engine_simple_add_table_by_locale (IBusEngineSimple *simple,
             for (sys_lang = sys_langs; *sys_lang; sys_lang++) {
                 if (g_ascii_strncasecmp (*lang, *sys_lang,
                                          strlen (*sys_lang)) == 0) {
-                    path = g_build_filename (X11_DATADIR,
+                    path = g_build_filename (X11_LOCALEDATADIR,
                                              *lang, "Compose", NULL);
                     break;
                 }
@@ -1462,7 +1461,7 @@ ibus_engine_simple_add_table_by_locale (IBusEngineSimple *simple,
             ibus_engine_simple_add_compose_file (simple, path);
         g_clear_pointer(&path, g_free);
     } else {
-        path = g_build_filename (X11_DATADIR, locale, "Compose", NULL);
+        path = g_build_filename (X11_LOCALEDATADIR, locale, "Compose", NULL);
         do {
             if (g_file_test (path, G_FILE_TEST_EXISTS))
                 break;

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -30,7 +30,7 @@ AM_CPPFLAGS = \
     @GLIB2_CFLAGS@                          \
     @GIO2_CFLAGS@                           \
     -DIBUS_DISABLE_DEPRECATION_WARNINGS     \
-    -DX11_DATA_PREFIX=\"$(X11_PREFIX)\"     \
+    -DX11_LOCALEDATADIR=\"$(X11_LOCALEDATADIR)\" \
     -I$(top_srcdir)/src                     \
     -I$(top_builddir)/src                   \
     $(NULL)

--- a/src/tests/ibus-compose.c
+++ b/src/tests/ibus-compose.c
@@ -6,7 +6,6 @@
 #define GREEN "\033[0;32m"
 #define RED   "\033[0;31m"
 #define NC    "\033[0m"
-#define X11_DATADIR X11_DATA_PREFIX "/share/X11/locale"
 
 IBusBus *m_bus;
 gchar *m_compose_file;
@@ -36,7 +35,7 @@ get_compose_path ()
             break;
         if (g_strcmp0 (*l, "C") == 0)
             break;
-        compose_path = g_build_filename (X11_DATADIR,
+        compose_path = g_build_filename (X11_LOCALEDATADIR,
                                          *l,
                                          "Compose",
                                          NULL);


### PR DESCRIPTION
ibus 1.5.28 assumes X11 locale Compose data directories are in ```X11_DATA_PREFIX "/share/X11/locale"```
but several systems (at least FreeBSD and NetBSD) have them in ```${X11_PREFIX}/lib/X11/locale```
for some reason, maybe for loadable libraries:
https://github.com/freedesktop/xorg-lib-libX11/blob/20a3f99eba5001925b8b313da3accb7900eb1927/configure.ac#L336-L340

This commit adds a simple check against `$X11_PREFIX/share/X11/locale/locale.dir` and `$X11_PREFIX/lib/X11/locale/locale.dir` to determine Compose dir and define it as `X11_LOCALEDATADIR` during configure.

FreeBSD ports Compose dir:
https://github.com/freebsd/freebsd-ports/blob/e3df77b3abbd33bed8c5c7cacad4a3a242bde13f/x11/libX11/pkg-plist#L16

NetBSD Compose dir:
https://github.com/NetBSD/src/blob/aba449a55bf91b44bc68f542edd9afa341962b89/distrib/sets/lists/xbase/mi#L347