### PR TITLE
configure: Fix cross compiling with gen-internal-compose-table

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -130,6 +130,7 @@ AC_PROG_CC_STDC
 AM_PROG_VALAC([0.20])
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
+AX_PROG_CC_FOR_BUILD
 
 # i18n stuff
 AM_GNU_GETTEXT_VERSION([0.19.8])
@@ -150,6 +151,9 @@ AC_CHECK_FUNCS(daemon)
 # Check dlclose() in libc.so.
 AC_CHECK_LIB(c, dlclose, LIBDL="", [AC_CHECK_LIB(dl, dlclose, LIBDL="-ldl")])
 AC_SUBST(LIBDL)
+
+# Check if cross compiling.
+AM_CONDITIONAL(CROSS_COMPILING, test "x$cross_compiling" = xyes)
 
 # Check endianness.
 AC_C_BIGENDIAN([ENDIAN=big], [ENDIAN=little], [ENDIAN=unknown], [ENDIAN=big])
@@ -183,6 +187,14 @@ AH_BOTTOM([
 #  include <errno.h>
 #endif
 ])
+
+if test "x$cross_compiling" = "xyes"; then
+PKG_PROG_PKG_CONFIG_FOR_BUILD
+GLIB_CFLAGS_FOR_BUILD=`$PKG_CONFIG_FOR_BUILD --cflags glib-2.0 gobject-2.0 gio-2.0 gio-unix-2.0 gthread-2.0`
+GLIB_LIBS_FOR_BUILD=`$PKG_CONFIG_FOR_BUILD --libs glib-2.0 gobject-2.0 gio-2.0 gio-unix-2.0 gthread-2.0`
+AC_SUBST(GLIB_CFLAGS_FOR_BUILD)
+AC_SUBST(GLIB_LIBS_FOR_BUILD)
+fi
 
 # --disable-tests option.
 AC_ARG_ENABLE(tests,

--- a/m4/Makefile.am
+++ b/m4/Makefile.am
@@ -22,7 +22,9 @@
 
 EXTRA_DIST = \
     as-version.m4 \
+    ax_prog_cc_for_build.m4 \
     ibuslocale.m4 \
+    pkg_config_for_build.m4 \
     vapigen.m4 \
     $(NULL)
 

--- a/m4/ax_prog_cc_for_build.m4
+++ b/m4/ax_prog_cc_for_build.m4
@@ -1,0 +1,155 @@
+# ===========================================================================
+#   https://www.gnu.org/software/autoconf-archive/ax_prog_cc_for_build.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_PROG_CC_FOR_BUILD
+#
+# DESCRIPTION
+#
+#   This macro searches for a C compiler that generates native executables,
+#   that is a C compiler that surely is not a cross-compiler. This can be
+#   useful if you have to generate source code at compile-time like for
+#   example GCC does.
+#
+#   The macro sets the CC_FOR_BUILD and CPP_FOR_BUILD macros to anything
+#   needed to compile or link (CC_FOR_BUILD) and preprocess (CPP_FOR_BUILD).
+#   The value of these variables can be overridden by the user by specifying
+#   a compiler with an environment variable (like you do for standard CC).
+#
+#   It also sets BUILD_EXEEXT and BUILD_OBJEXT to the executable and object
+#   file extensions for the build platform, and GCC_FOR_BUILD to `yes' if
+#   the compiler we found is GCC. All these variables but GCC_FOR_BUILD are
+#   substituted in the Makefile.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Paolo Bonzini <bonzini@gnu.org>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved. This file is offered as-is, without any
+#   warranty.
+
+#serial 21
+
+AU_ALIAS([AC_PROG_CC_FOR_BUILD], [AX_PROG_CC_FOR_BUILD])
+AC_DEFUN([AX_PROG_CC_FOR_BUILD], [dnl
+AC_REQUIRE([AC_PROG_CC])dnl
+AC_REQUIRE([AC_PROG_CPP])dnl
+AC_REQUIRE([AC_CANONICAL_BUILD])dnl
+
+dnl Use the standard macros, but make them use other variable names
+dnl
+pushdef([ac_cv_prog_CPP], ac_cv_build_prog_CPP)dnl
+pushdef([ac_cv_prog_cc_c89], ac_cv_build_prog_cc_c89)dnl
+pushdef([ac_cv_prog_cc_c99], ac_cv_build_prog_cc_c99)dnl
+pushdef([ac_cv_prog_cc_c11], ac_cv_build_prog_cc_c11)dnl
+pushdef([ac_cv_prog_gcc], ac_cv_build_prog_gcc)dnl
+pushdef([ac_cv_prog_cc_works], ac_cv_build_prog_cc_works)dnl
+pushdef([ac_cv_prog_cc_cross], ac_cv_build_prog_cc_cross)dnl
+pushdef([ac_cv_prog_cc_g], ac_cv_build_prog_cc_g)dnl
+pushdef([ac_cv_c_compiler_gnu], ac_cv_build_c_compiler_gnu)dnl
+pushdef([ac_cv_exeext], ac_cv_build_exeext)dnl
+pushdef([ac_cv_objext], ac_cv_build_objext)dnl
+pushdef([ac_exeext], ac_build_exeext)dnl
+pushdef([ac_objext], ac_build_objext)dnl
+pushdef([CC], CC_FOR_BUILD)dnl
+pushdef([CPP], CPP_FOR_BUILD)dnl
+pushdef([GCC], GCC_FOR_BUILD)dnl
+pushdef([CFLAGS], CFLAGS_FOR_BUILD)dnl
+pushdef([CPPFLAGS], CPPFLAGS_FOR_BUILD)dnl
+pushdef([EXEEXT], BUILD_EXEEXT)dnl
+pushdef([LDFLAGS], LDFLAGS_FOR_BUILD)dnl
+pushdef([OBJEXT], BUILD_OBJEXT)dnl
+pushdef([host], build)dnl
+pushdef([host_alias], build_alias)dnl
+pushdef([host_cpu], build_cpu)dnl
+pushdef([host_vendor], build_vendor)dnl
+pushdef([host_os], build_os)dnl
+pushdef([ac_cv_host], ac_cv_build)dnl
+pushdef([ac_cv_host_alias], ac_cv_build_alias)dnl
+pushdef([ac_cv_host_cpu], ac_cv_build_cpu)dnl
+pushdef([ac_cv_host_vendor], ac_cv_build_vendor)dnl
+pushdef([ac_cv_host_os], ac_cv_build_os)dnl
+pushdef([ac_tool_prefix], ac_build_tool_prefix)dnl
+pushdef([am_cv_CC_dependencies_compiler_type], am_cv_build_CC_dependencies_compiler_type)dnl
+pushdef([am_cv_prog_cc_c_o], am_cv_build_prog_cc_c_o)dnl
+pushdef([cross_compiling], cross_compiling_build)dnl
+
+cross_compiling_build=no
+
+ac_build_tool_prefix=
+AS_IF([test -n "$build"],      [ac_build_tool_prefix="$build-"],
+      [test -n "$build_alias"],[ac_build_tool_prefix="$build_alias-"])
+
+AC_LANG_PUSH([C])
+
+dnl The pushdef([ac_cv_c_compiler_gnu], ...) currently does not cover
+dnl the use of this variable in _AC_LANG_COMPILER_GNU called by
+dnl AC_PROG_CC. Unset this cache variable temporarily as a workaround.
+was_set_c_compiler_gnu=${[ac_cv_c_compiler_gnu]+y}
+AS_IF([test ${was_set_c_compiler_gnu}],
+    [saved_c_compiler_gnu=$[ac_cv_c_compiler_gnu]
+    AS_UNSET([[ac_cv_c_compiler_gnu]])])
+
+AC_PROG_CC
+
+dnl Restore ac_cv_c_compiler_gnu
+AS_IF([test ${was_set_c_compiler_gnu}],
+  [[ac_cv_c_compiler_gnu]=$[saved_c_compiler_gnu]])
+
+_AC_COMPILER_EXEEXT
+_AC_COMPILER_OBJEXT
+AC_PROG_CPP
+
+dnl Restore the old definitions
+dnl
+popdef([cross_compiling])dnl
+popdef([am_cv_prog_cc_c_o])dnl
+popdef([am_cv_CC_dependencies_compiler_type])dnl
+popdef([ac_tool_prefix])dnl
+popdef([ac_cv_host_os])dnl
+popdef([ac_cv_host_vendor])dnl
+popdef([ac_cv_host_cpu])dnl
+popdef([ac_cv_host_alias])dnl
+popdef([ac_cv_host])dnl
+popdef([host_os])dnl
+popdef([host_vendor])dnl
+popdef([host_cpu])dnl
+popdef([host_alias])dnl
+popdef([host])dnl
+popdef([OBJEXT])dnl
+popdef([LDFLAGS])dnl
+popdef([EXEEXT])dnl
+popdef([CPPFLAGS])dnl
+popdef([CFLAGS])dnl
+popdef([GCC])dnl
+popdef([CPP])dnl
+popdef([CC])dnl
+popdef([ac_objext])dnl
+popdef([ac_exeext])dnl
+popdef([ac_cv_objext])dnl
+popdef([ac_cv_exeext])dnl
+popdef([ac_cv_c_compiler_gnu])dnl
+popdef([ac_cv_prog_cc_g])dnl
+popdef([ac_cv_prog_cc_cross])dnl
+popdef([ac_cv_prog_cc_works])dnl
+popdef([ac_cv_prog_cc_c89])dnl
+popdef([ac_cv_prog_gcc])dnl
+popdef([ac_cv_prog_CPP])dnl
+
+dnl restore global variables ac_ext, ac_cpp, ac_compile,
+dnl ac_link, ac_compiler_gnu (dependant on the current
+dnl language after popping):
+AC_LANG_POP([C])
+
+dnl Finally, set Makefile variables
+dnl
+AC_SUBST(BUILD_EXEEXT)dnl
+AC_SUBST(BUILD_OBJEXT)dnl
+AC_SUBST([CFLAGS_FOR_BUILD])dnl
+AC_SUBST([CPPFLAGS_FOR_BUILD])dnl
+AC_SUBST([LDFLAGS_FOR_BUILD])dnl
+])

--- a/m4/pkg_config_for_build.m4
+++ b/m4/pkg_config_for_build.m4
@@ -1,0 +1,20 @@
+# PKG_PROG_PKG_CONFIG_FOR_BUILD([MIN-VERSION])
+# ----------------------------------
+AC_DEFUN([PKG_PROG_PKG_CONFIG_FOR_BUILD],
+[m4_pattern_allow([^PKG_CONFIG_FOR_BUILD$])
+AC_ARG_VAR([PKG_CONFIG_FOR_BUILD], [path to build system's pkg-config utility])
+
+if test "x$ac_cv_env_PKG_CONFIG_FOR_BUILD_set" != "xset"; then
+	AC_PATH_PROG([PKG_CONFIG_FOR_BUILD], [pkg-config])
+fi
+if test -n "$PKG_CONFIG_FOR_BUILD"; then
+	_pkg_for_build_min_version=m4_default([$1], [0.9.0])
+	AC_MSG_CHECKING([build system's pkg-config is at least version $_pkg_min_version])
+	if $PKG_CONFIG_FOR_BUILD --atleast-pkgconfig-version $_pkg_min_version; then
+		AC_MSG_RESULT([yes])
+	else
+		AC_MSG_RESULT([no])
+		PKG_CONFIG_FOR_BUILD=""
+	fi
+fi[]dnl
+])# PKG_PROG_PKG_CONFIG_FOR_BUILD

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -46,9 +46,6 @@ noinst_PROGRAMS = gen-internal-compose-table
 # C preprocessor flags
 AM_CPPFLAGS =                                           \
     -DG_LOG_DOMAIN=\"IBUS\"                             \
-    @GLIB2_CFLAGS@                                      \
-    @GOBJECT2_CFLAGS@                                   \
-    @GIO2_CFLAGS@                                       \
     -DIBUS_CACHE_DIR=\""$(localstatedir)/cache/ibus"\"  \
     -DIBUS_DATA_DIR=\"$(pkgdatadir)\"                   \
     -DIBUS_DISABLE_DEPRECATION_WARNINGS                 \
@@ -64,6 +61,11 @@ libibus_1_0_la_LIBADD =     \
     @GLIB2_LIBS@            \
     @GOBJECT2_LIBS@         \
     @GIO2_LIBS@             \
+    $(NULL)
+libibus_1_0_la_CFLAGS =     \
+    @GLIB2_CFLAGS@          \
+    @GOBJECT2_CFLAGS@       \
+    @GIO2_CFLAGS@           \
     $(NULL)
 libibus_1_0_la_LDFLAGS =            \
     -no-undefined                   \
@@ -107,7 +109,7 @@ ibus_sources =              \
     ibusxevent.c            \
     ibusxml.c               \
     $(NULL)
-libibus_1_0_la_SOURCES =    \
+libibus_sources =           \
     ibuscomposetable.c      \
     ibusenumtypes.c         \
     ibusmarshalers.c        \
@@ -166,6 +168,7 @@ ibus_headers =              \
     ibusxevent.h            \
     ibusxml.h               \
     $(NULL)
+libibus_1_0_la_SOURCES = $(libibus_sources)
 ibusincludedir = $(includedir)/ibus-@IBUS_API_VERSION@
 ibus_public_headers =       \
     $(ibus_headers)         \
@@ -188,6 +191,35 @@ noinst_HEADERS =            \
     $(ibus_private_headers) \
     $(NULL)
 
+if CROSS_COMPILING
+# Avoid libtool when building native libraries
+libnativeibus =
+parser_extra_sources = $(libibus_sources)
+
+glib_cflags = @GLIB_CFLAGS_FOR_BUILD@
+glib_libs = @GLIB_LIBS_FOR_BUILD@
+
+$(noinst_PROGRAMS): CC=$(CC_FOR_BUILD)
+$(noinst_PROGRAMS): CCLD=$(CC_FOR_BUILD)
+$(noinst_PROGRAMS): CFLAGS=$(CFLAGS_FOR_BUILD)
+$(noinst_PROGRAMS): CPPFLAGS=$(CPPFLAGS_FOR_BUILD)
+$(noinst_PROGRAMS): LDFLAGS=$(LDFLAGS_FOR_BUILD)
+else
+libnativeibus = $(libibus)
+parser_extra_sources =
+
+glib_libs =             \
+    @GLIB2_LIBS@        \
+    @GOBJECT2_LIBS@     \
+    @GIO2_LIBS@         \
+    $(NULL)
+glib_cflags =           \
+    @GLIB2_CFLAGS@      \
+    @GOBJECT2_CFLAGS@   \
+    @GIO2_CFLAGS@       \
+    $(NULL)
+endif
+
 gen_internal_compose_table_SOURCES = \
     gencomposetable.c   \
     ibuscomposetable.c  \
@@ -195,11 +227,12 @@ gen_internal_compose_table_SOURCES = \
     ibuskeynames.c      \
     ibuskeyuni.c        \
     $(NULL)
-gen_internal_compose_table_CFLAGS = $(AM_CFLAGS)
+gen_internal_compose_table_CFLAGS =  \
+    $(AM_CFLAGS)        \
+    $(glib_cflags)      \
+    $(NULL)
 gen_internal_compose_table_LDADD = \
-    @GLIB2_LIBS@        \
-    @GOBJECT2_LIBS@     \
-    @GIO2_LIBS@         \
+    $(glib_libs)        \
     $(NULL)
 
 BUILT_SOURCES =                 \
@@ -362,15 +395,15 @@ install-data-hook:
 
 emoji_parser_SOURCES =          \
     emoji-parser.c              \
+    $(parser_extra_sources)     \
     $(NULL)
 emoji_parser_CFLAGS =           \
-    $(GLIB2_CFLAGS)             \
-    $(GOBJECT2_CFLAGS)          \
+    $(AM_CFLAGS)                \
+    $(glib_cflags)              \
     $(NULL)
 emoji_parser_LDADD =            \
-    $(libibus)                  \
-    $(GLIB2_LIBS)               \
-    $(GOBJECT2_LIBS)            \
+    $(libnativeibus)            \
+    $(glib_libs)                \
     $(NULL)
 endif
 
@@ -407,13 +440,15 @@ ibusunicodegen.h:
 
 unicode_parser_SOURCES =        \
     unicode-parser.c            \
+    $(parser_extra_sources)     \
     $(NULL)
 unicode_parser_CFLAGS =         \
-    $(GLIB2_CFLAGS)             \
+    $(AM_CFLAGS)                \
+    $(glib_cflags)              \
     $(NULL)
 unicode_parser_LDADD =          \
-    $(GLIB2_LIBS)               \
-    $(libibus)                  \
+    $(glib_libs)                \
+    $(libnativeibus)            \
     $(NULL)
 endif
 


### PR DESCRIPTION
Use AX_PROG_CC_FOR_BUILD to get build CC/CFLAGS/LDFLAGS/etc. Use AC_COMPILE_IFELSE insead of AC_RUN_IFELSE.

https://github.com/ibus/ibus/issues/2479