### PR TITLE
makefile: don't gzip the man pages 

### DIFF
--- a/bus/Makefile.am
+++ b/bus/Makefile.am
@@ -163,12 +163,7 @@ test_stress_LDADD = \
 	$(NULL)
 
 EXTRA_DIST =                \
-	$(man_one_in_files)     \
 	marshalers.list         \
-	$(NULL)
-
-CLEANFILES = \
-	$(man_one_DATA)            \
 	$(NULL)
 
 $(libibus):
@@ -179,12 +174,7 @@ test: ibus-daemon
 		G_DEBUG=fatal_warnings \
 		$(builddir)/ibus-daemon -v
 
-man_one_in_files = ibus-daemon.1.in
-man_one_DATA = $(man_one_in_files:.1.in=.1)
+man_one_DATA = ibus-daemon.1
 man_onedir = $(mandir)/man1
-%.1: %.1.in
-	$(AM_V_GEN) sed \
-		-e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
-		mv $@.tmp $@
 
 -include $(top_srcdir)/git.mk

--- a/bus/Makefile.am
+++ b/bus/Makefile.am
@@ -169,7 +169,6 @@ EXTRA_DIST =                \
 
 CLEANFILES = \
 	$(man_one_DATA)            \
-	$(man_one_files)        \
 	$(NULL)
 
 $(libibus):
@@ -181,14 +180,11 @@ test: ibus-daemon
 		$(builddir)/ibus-daemon -v
 
 man_one_in_files = ibus-daemon.1.in
-man_one_files = $(man_one_in_files:.1.in=.1)
-man_one_DATA =$(man_one_files:.1=.1.gz) 
+man_one_DATA = $(man_one_in_files:.1.in=.1)
 man_onedir = $(mandir)/man1
 %.1: %.1.in
 	$(AM_V_GEN) sed \
 		-e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
 		mv $@.tmp $@
-%.1.gz: %.1
-	$(AM_V_GEN) gzip -c $< > $@.tmp && mv $@.tmp $@
 
 -include $(top_srcdir)/git.mk

--- a/configure.ac
+++ b/configure.ac
@@ -831,6 +831,7 @@ bindings/Makefile
 bindings/pygobject/Makefile
 bindings/vala/Makefile
 bus/Makefile
+bus/ibus-daemon.1
 bus/services/Makefile
 client/Makefile
 client/gtk2/Makefile
@@ -847,6 +848,8 @@ data/icons/Makefile
 data/its/Makefile
 data/keymaps/Makefile
 data/dconf/Makefile
+data/dconf/00-upstream-settings.5
+data/dconf/ibus.5
 docs/Makefile
 docs/reference/Makefile
 docs/reference/ibus/ibus-docs.sgml
@@ -858,13 +861,16 @@ ibus/interface/Makefile
 m4/Makefile
 portal/Makefile
 setup/Makefile
+setup/ibus-setup.1
 src/Makefile
 src/compose/Makefile
 src/ibusversion.h
 src/tests/Makefile
 tools/Makefile
+tools/ibus.1
 ui/Makefile
 ui/gtk3/Makefile
+ui/gtk3/ibus-emoji.7
 util/Makefile
 util/IMdkit/Makefile
 Makefile

--- a/data/dconf/Makefile.am
+++ b/data/dconf/Makefile.am
@@ -37,13 +37,8 @@ dconfdb_DATA = 00-upstream-settings
 	$(AM_V_GEN) $(srcdir)/make-dconf-override-db.sh > $@ || \
 		{ rc=$$?; $(RM) -rf $@; exit $$rc; }
 
-man_5_in_files = 00-upstream-settings.5.in ibus.5.in
-man_5_DATA = $(man_5_in_files:.5.in=.5)
+man_5_DATA = 00-upstream-settings.5 ibus.5
 man_5dir = $(mandir)/man5
-%.5: %.5.in
-	$(AM_V_GEN) sed \
-	    -e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
-	    mv $@.tmp $@
 
 install-data-hook:
 	if test -z "$(DESTDIR)"; then \
@@ -52,14 +47,9 @@ install-data-hook:
 
 EXTRA_DIST = \
     $(gsettings_SCHEMAS) \
-    $(man_5_in_files) \
     make-dconf-override-db.sh \
     profile/ibus \
     00-upstream-settings \
-    $(NULL)
-
-CLEANFILES = \
-    $(man_5_DATA) \
     $(NULL)
 
 MAINTAINERCLEANFILES = \

--- a/data/dconf/Makefile.am
+++ b/data/dconf/Makefile.am
@@ -38,15 +38,12 @@ dconfdb_DATA = 00-upstream-settings
 		{ rc=$$?; $(RM) -rf $@; exit $$rc; }
 
 man_5_in_files = 00-upstream-settings.5.in ibus.5.in
-man_5_files = $(man_5_in_files:.5.in=.5)
-man_5_DATA =$(man_5_files:.5=.5.gz)
+man_5_DATA = $(man_5_in_files:.5.in=.5)
 man_5dir = $(mandir)/man5
 %.5: %.5.in
 	$(AM_V_GEN) sed \
 	    -e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
 	    mv $@.tmp $@
-%.5.gz: %.5
-	$(AM_V_GEN) gzip -c $< > $@.tmp && mv $@.tmp $@
 
 install-data-hook:
 	if test -z "$(DESTDIR)"; then \
@@ -63,7 +60,6 @@ EXTRA_DIST = \
 
 CLEANFILES = \
     $(man_5_DATA) \
-    $(man_5_files) \
     $(NULL)
 
 MAINTAINERCLEANFILES = \

--- a/setup/Makefile.am
+++ b/setup/Makefile.am
@@ -56,20 +56,16 @@ org.freedesktop.IBus.Setup.desktop: ibus-setup.desktop
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
 man_one_in_files = ibus-setup.1.in
-man_one_files = $(man_one_in_files:.1.in=.1)
-man_one_DATA =$(man_one_files:.1=.1.gz) 
+man_one_DATA = $(man_one_in_files:.1.in=.1)
 man_onedir = $(mandir)/man1
 %.1: %.1.in
 	$(AM_V_GEN) sed \
 		-e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
 		mv $@.tmp $@
-%.1.gz: %.1
-	$(AM_V_GEN) gzip -c $< > $@.tmp && mv $@.tmp $@
 
 CLEANFILES = \
     $(desktop_DATA) \
     $(man_one_DATA) \
-    $(man_one_files) \
     *.pyc \
     ibus-setup \
     $(NULL)

--- a/setup/Makefile.am
+++ b/setup/Makefile.am
@@ -55,24 +55,17 @@ desktopdir = $(datadir)/applications
 org.freedesktop.IBus.Setup.desktop: ibus-setup.desktop
 	$(AM_V_GEN) $(MSGFMT) --desktop --template $< -d $(top_srcdir)/po -o $@
 
-man_one_in_files = ibus-setup.1.in
-man_one_DATA = $(man_one_in_files:.1.in=.1)
+man_one_DATA = ibus-setup.1
 man_onedir = $(mandir)/man1
-%.1: %.1.in
-	$(AM_V_GEN) sed \
-		-e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
-		mv $@.tmp $@
 
 CLEANFILES = \
     $(desktop_DATA) \
-    $(man_one_DATA) \
     *.pyc \
     ibus-setup \
     $(NULL)
 
 EXTRA_DIST = \
     $(desktop_notrans_files) \
-    $(man_one_in_files) \
     ibus-setup.in \
     setup.ui \
     $(NULL)

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -112,24 +112,14 @@ libibusimmodule_la_LDFLAGS = \
     -export-symbols-regex "ibus_.*"                     \
     $(NULL)
 
-man_one_in_files = ibus.1.in
-man_one_DATA = $(man_one_in_files:.1.in=.1)
+man_one_DATA = ibus.1
 man_onedir = $(mandir)/man1
-%.1: %.1.in
-	$(AM_V_GEN) sed \
-		-e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
-		mv $@.tmp $@
 
 EXTRA_DIST = \
     $(ibus_immodule_vapi) \
     $(ibusimmodule_gir) \
-    $(man_one_in_files) \
     ibus.bash \
     IBusIMModule-1.0.metadata \
-    $(NULL)
-
-CLEANFILES = \
-    $(man_one_DATA) \
     $(NULL)
 
 if ENABLE_EMOJI_DICT

--- a/tools/Makefile.am
+++ b/tools/Makefile.am
@@ -113,15 +113,12 @@ libibusimmodule_la_LDFLAGS = \
     $(NULL)
 
 man_one_in_files = ibus.1.in
-man_one_files = $(man_one_in_files:.1.in=.1)
-man_one_DATA =$(man_one_files:.1=.1.gz)
+man_one_DATA = $(man_one_in_files:.1.in=.1)
 man_onedir = $(mandir)/man1
 %.1: %.1.in
 	$(AM_V_GEN) sed \
 		-e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
 		mv $@.tmp $@
-%.1.gz: %.1
-	$(AM_V_GEN) gzip -c $< > $@.tmp && mv $@.tmp $@
 
 EXTRA_DIST = \
     $(ibus_immodule_vapi) \
@@ -133,7 +130,6 @@ EXTRA_DIST = \
 
 CLEANFILES = \
     $(man_one_DATA) \
-    $(man_one_files) \
     $(NULL)
 
 if ENABLE_EMOJI_DICT

--- a/ui/gtk3/Makefile.am
+++ b/ui/gtk3/Makefile.am
@@ -147,8 +147,6 @@ emoji_headers =         \
     ibusemojidialog.h   \
     $(NULL)
 
-man_seven_in_files = ibus-emoji.7.in
-
 # References:
 # libappindicator/src/notification-item.xml
 # libappindicator/src/notification-watcher.xml
@@ -156,7 +154,6 @@ man_seven_in_files = ibus-emoji.7.in
 # kdelibs/kdeui/knotifications/src/org.kde.StatusNotifierWatcher.xml
 EXTRA_DIST =                            \
     $(emoji_headers)                    \
-    $(man_seven_in_files)               \
     emojierapp.vala                     \
     extension.vala                      \
     gtkextension.xml.in                 \
@@ -257,12 +254,8 @@ panelbinding.o: $(srcdir)/panelbinding.c
 
 MAINTAINERCLEANFILES += extension.c panelbinding.c
 
-man_seven_DATA = $(man_seven_in_files:.7.in=.7)
+man_seven_DATA = ibus-emoji.7
 man_sevendir = $(mandir)/man7
-%.7: %.7.in
-	$(AM_V_GEN) sed \
-	    -e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
-	    mv $@.tmp $@
 
 desktop_in_files = \
     ibus-ui-emojier.desktop.in \
@@ -289,7 +282,6 @@ org.freedesktop.IBus.Panel.Extension.Gtk3.desktop: ibus-extension-gtk3.desktop
 CLEANFILES += \
     $(desktop_DATA) \
     $(desktop_notrans_files) \
-    $(man_seven_DATA) \
     $(NULL)
 
 endif

--- a/ui/gtk3/Makefile.am
+++ b/ui/gtk3/Makefile.am
@@ -257,15 +257,12 @@ panelbinding.o: $(srcdir)/panelbinding.c
 
 MAINTAINERCLEANFILES += extension.c panelbinding.c
 
-man_seven_files = $(man_seven_in_files:.7.in=.7)
-man_seven_DATA =$(man_seven_files:.7=.7.gz)
+man_seven_DATA = $(man_seven_in_files:.7.in=.7)
 man_sevendir = $(mandir)/man7
 %.7: %.7.in
 	$(AM_V_GEN) sed \
 	    -e 's|@VERSION[@]|$(VERSION)|g' $< > $@.tmp && \
 	    mv $@.tmp $@
-%.7.gz: %.7
-	$(AM_V_GEN) gzip -c $< > $@.tmp && mv $@.tmp $@
 
 desktop_in_files = \
     ibus-ui-emojier.desktop.in \
@@ -293,7 +290,6 @@ CLEANFILES += \
     $(desktop_DATA) \
     $(desktop_notrans_files) \
     $(man_seven_DATA) \
-    $(man_seven_files) \
     $(NULL)
 
 endif


### PR DESCRIPTION
Drop the gzip step from the manpages - distributions already do that as
needed. In addition this resolves the final reproducibility issue with
ibus.

With the above done, we can remove the explicit sed/EXTRA_DIST/CLEANFILES handling - AC_CONFIG_FILES does it for us.