### PR TITLE
configure.ac: Run autoupdate

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -64,7 +64,7 @@ AC_SUBST(VALA_TARGET_GLIB_VERSION)
 # Init automake.
 AM_INIT_AUTOMAKE([1.11.1 parallel-tests])
 AM_MAINTAINER_MODE([enable])
-AC_GNU_SOURCE
+AC_USE_SYSTEM_EXTENSIONS
 
 # Support silent build rules. Disable
 # by either passing --disable-silent-rules to configure or passing V=1
@@ -126,7 +126,6 @@ AC_SUBST(DATE_DISPLAY)
 # Check for programs.
 AC_PROG_CC
 AM_PROG_CC_C_O
-AC_PROG_CC_STDC
 AM_PROG_VALAC([0.20])
 AC_PROG_INSTALL
 AC_PROG_MAKE_SET
@@ -136,9 +135,9 @@ AM_GNU_GETTEXT_VERSION([0.19.8])
 AM_GNU_GETTEXT([external])
 
 # Define PACKAGE_VERSION_* variables.
-AM_DISABLE_STATIC
-AC_ISC_POSIX
-AC_HEADER_STDC
+AC_DISABLE_STATIC([])
+AC_SEARCH_LIBS([strerror],[cposix])
+
 LT_INIT
 
 # Check header filess.


### PR DESCRIPTION
Avoids these warnings when running autogen.sh:

````
configure.ac:67: warning: The macro `AC_GNU_SOURCE' is obsolete.
configure.ac:67: You should run autoupdate.
./lib/autoconf/specific.m4:311: AC_GNU_SOURCE is expanded from...
configure.ac:67: the top level
configure.ac:129: warning: The macro `AC_PROG_CC_STDC' is obsolete.
configure.ac:129: You should run autoupdate.
./lib/autoconf/c.m4:1671: AC_PROG_CC_STDC is expanded from...
configure.ac:129: the top level
configure.ac:139: warning: The macro `AM_DISABLE_STATIC' is obsolete.
configure.ac:139: You should run autoupdate.
m4/ltoptions.m4:260: AM_DISABLE_STATIC is expanded from...
configure.ac:139: the top level
configure.ac:140: warning: The macro `AC_ISC_POSIX' is obsolete.
configure.ac:140: You should run autoupdate.
./lib/autoconf/specific.m4:549: AC_ISC_POSIX is expanded from...
configure.ac:140: the top level
configure.ac:141: warning: The macro `AC_HEADER_STDC' is obsolete.
configure.ac:141: You should run autoupdate.
./lib/autoconf/headers.m4:704: AC_HEADER_STDC is expanded from...
configure.ac:141: the top level
````