### PR TITLE
build: Use autoconf substitutions

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -365,13 +365,13 @@ emoji_parser_SOURCES =          \
     emoji-parser.c              \
     $(NULL)
 emoji_parser_CFLAGS =           \
-    $(GLIB2_CFLAGS)             \
-    $(GOBJECT2_CFLAGS)          \
+    @GLIB2_CFLAGS@              \
+    @GOBJECT2_CFLAGS@           \
     $(NULL)
 emoji_parser_LDADD =            \
     $(libibus)                  \
-    $(GLIB2_LIBS)               \
-    $(GOBJECT2_LIBS)            \
+    @GLIB2_LIBS@                \
+    @GOBJECT2_LIBS@             \
     $(NULL)
 endif
 
@@ -410,10 +410,10 @@ unicode_parser_SOURCES =        \
     unicode-parser.c            \
     $(NULL)
 unicode_parser_CFLAGS =         \
-    $(GLIB2_CFLAGS)             \
+    @GLIB2_CFLAGS@             \
     $(NULL)
 unicode_parser_LDADD =          \
-    $(GLIB2_LIBS)               \
+    @GLIB2_LIBS@               \
     $(libibus)                  \
     $(NULL)
 endif


### PR DESCRIPTION
These are autoconf substituted variables, not automake variables. As such, this fixes the generated Makefile to contain proper values. E.g. comparing before and after:

````
 emoji_parser_LDADD = \
     $(libibus)                  \
-    $(GLIB2_LIBS)               \
-    $(GOBJECT2_LIBS)            \
+    -lglib-2.0                 \
+    -lgobject-2.0 -lglib-2.0              \
     $(NULL)
````

Split from Split from https://github.com/ibus/ibus/pull/2523/