### PR TITLE
Fix typo in src/ibusservice.h

### DIFF
--- a/src/ibusservice.h
+++ b/src/ibusservice.h
@@ -266,7 +266,7 @@ gboolean         ibus_service_class_add_interfaces
  * returned but any interfaces are not freed.
  */
 int              ibus_service_class_free_interfaces
-                                                (IBusServiceClass   *class,
+                                                (IBusServiceClass   *klass,
                                                  int                 depth);
 
 G_END_DECLS


### PR DESCRIPTION
Fixes: https://github.com/ibus/ibus/issues/2550

Changed this to a draft, since it's not the right fix and/or not sufficient.

In any case the problem when building plasma-desktop seems to be that "class" is a reserved name in C++.

@fujiwarat: You should probably look at it.