### PR TITLE
Do not update zero length preedit text

### DIFF
--- a/src/ibusengine.c
+++ b/src/ibusengine.c
@@ -1326,6 +1326,17 @@ ibus_engine_service_method_call (IBusService           *service,
             return;
         }
         priv->enable_extension = ibus_extension_event_is_enabled (event);
+        /* IBusEngineSimple no longer calls to hide the preedit with the zero
+         * lenght and this sends the null preedit here when the emojier
+         * commits or escapes the emoji preedit text.
+         * TODO: Do we need a signal for the parent engines to inform this
+         * information because some engines don't wish to hide their preedit
+         * with hiding the emoji preedit?
+         */
+        if (!priv->enable_extension) {
+            IBusText *text = ibus_text_new_from_static_string ("");
+            ibus_engine_update_preedit_text (engine, text, 0, FALSE);
+        }
         g_dbus_method_invocation_return_value (invocation, NULL);
         return;
     }

--- a/src/ibusenginesimple.c
+++ b/src/ibusenginesimple.c
@@ -385,7 +385,7 @@ ibus_engine_simple_update_preedit_text (IBusEngineSimple *simple)
 
     if (s->len == 0) {
         /* #2536 IBusEngine can inherit IBusEngineSimple for comopse keys.
-         * If the previous preedit is zero, the current preedit does not 
+         * If the previous preedit is zero, the current preedit does not
          * need to be hidden here at least because ibus-daemon could have
          * another preedit for the child IBusEnigne likes m17n and caclling
          * ibus_engine_hide_preedit_text() here could cause a reset of


### PR DESCRIPTION
Several engines can inherit IBusEngieSimple for the compose key support likes Anthy, Hangul, M17n and it could have the duplicated preedit text between the engine and the parent IBusEngineSimple and it could update the preedit text mutually by mistake.

Then the preedit text should not be hidden for zero length at least. This update might not be enough but hope to fix the cursor position reset with hiding the preedit text against the reported issue with `m17n:sa:itrans` engine.

BUG=https://github.com/ibus/ibus/issues/2536