### PR TITLE
github/workflows: Revert DNF for Fedora 39

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -129,10 +129,7 @@ jobs:
             ;;
           fedora*)
             cat /etc/fedora-release
-            DNF=dnf5
-            if test "${{ matrix.container }}" = "fedora:38" ; then
-                DNF=dnf
-            fi
+            DNF=dnf
             echo "$DNF -y update"
             $DNF -y update
             echo "$DNF -y install git which"

--- a/autogen.sh
+++ b/autogen.sh
@@ -47,7 +47,7 @@ cd "$srcdir"
         rpm -q $FEDORA_PKG1 || exit 1
         rpm -q $FEDORA_PKG2 || exit 1
         rpm -q $FEDORA_PKG3 || exit 1
-        (grep -qE '37|38' /etc/fedora-release) && DNF=dnf || DNF=dnf5
+        DNF=dnf
         $DNF update --assumeno $FEDORA_PKG1 || exit 1
         $DNF update --assumeno $FEDORA_PKG2 || exit 1
         $DNF update --assumeno $FEDORA_PKG3 || exit 1


### PR DESCRIPTION
Seems DNF5 is deleted by default.

Fixes: https://github.com/ibus/ibus/commit/f05c12d