### PR TITLE
util/IMdkit: Fix typing freeze with barcode reader

### DIFF
--- a/util/IMdkit/i18nPtHdr.c
+++ b/util/IMdkit/i18nPtHdr.c
@@ -1757,6 +1757,7 @@ static void ProcessQueue (XIMS ims, CARD16 connect_id)
         switch (hdr->major_opcode)
         {
         case XIM_FORWARD_EVENT:
+            sync();
             ForwardEventMessageProc(ims, &call_data, p1);
             break;
         }


### PR DESCRIPTION
After libX11 is fixed about the XIM jumbled input issues, too quick focus change can causes a freeze with barcode reader. Seems the modifier key of Alt-Tab effects the input of the barcode reader but the new issue cannot be reproduced with debug messages.

Hence the new issue could effect the machine spec and timing. I can avoid the new issue with adding sync() instead of a debug message. I don't understand the issue fully but hope this fix.

BUG=https://github.com/ibus/ibus/issues/2560