### PR TITLE
configure: Don't do AC_CHECK_FILE when cross compiling 

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -349,11 +349,18 @@ fi
 AC_SUBST(X11_PREFIX)
 
 # Check locale dir for Compose files.
-AC_CHECK_FILE($X11_PREFIX/share/X11/locale/locale.dir,
-              X11_LOCALEDATADIR="$X11_PREFIX/share/X11/locale",
-              [AC_CHECK_FILE($X11_PREFIX/lib/X11/locale/locale.dir,
-                             X11_LOCALEDATADIR="$X11_PREFIX/lib/X11/locale",
-                             X11_LOCALEDATADIR="$(datadir)/X11/locale")])
+if test x"$cross_compiling" != xyes; then
+    AC_CHECK_FILE($X11_PREFIX/share/X11/locale/locale.dir,
+                  X11_LOCALEDATADIR="$X11_PREFIX/share/X11/locale",
+                  [AC_CHECK_FILE($X11_PREFIX/lib/X11/locale/locale.dir,
+                                 X11_LOCALEDATADIR="$X11_PREFIX/lib/X11/locale",
+                                 X11_LOCALEDATADIR="$(datadir)/X11/locale")])
+else
+    if test x"$X11_LOCALEDATADIR" == x; then
+        X11_LOCALEDATADIR="$X11_PREFIX/share/X11/locale"
+    fi
+    AC_MSG_RESULT([Skipping X11 locale directory check when cross compiling. Using: $X11_LOCALEDATADIR])
+fi
 AC_SUBST(X11_LOCALEDATADIR)
 
 if test x"$enable_wayland" = x"yes"; then


### PR DESCRIPTION
AC_CHECK_FILE() is not available when cross compiling.

This removes `AC_SUBST(X11_PREFIX)` as it is currently unused, if you want me to add it back, I can, as that does work correctly when cross compiling.
This also does not handle the situation where both the build machine and target machine have `X11/locale` in different directories.

If you don't want this to be an option, replacing `AC_CHECK_FILE()` with `test -f` also works for checking for the `X11/locale` directory in the host environment.

There is also the issue that this doesn't handle environments where the build machine and the target machine have `X11/locale` in different directories. This isn't an issue in my case, and is something that can be worked around in the build environment, but let me know if that is an issue.