### PR TITLE
ui/gtk3: Configure initial keymaps with localectl in Wayland

### DIFF
--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -509,7 +509,7 @@ class Panel : IBus.PanelService {
         string layouts;
         string variants;
         string option;
-        XKBLayout.get_layout(out layouts, out variants, out option);
+        m_xkblayout.get_layout(out layouts, out variants, out option);
 
         GLib.List<IBus.EngineDesc> xkb_engines =
                 new GLib.List<IBus.EngineDesc>();


### PR DESCRIPTION
`setxkbmap -query` returns US layout with Xwayland and it does not correspond to the session keymaps so ibus-panel now uses `localectl status` in Wayland but it does not provide the session XKB options against `setxkbmap` command in Xorg.
Need to think how to load or set the XKB options in Wayland later.

BUG=rhbz#2267615