### PR TITLE
Update action/checkout version in main.yml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -156,7 +156,7 @@ jobs:
           echo $GITHUB_WORKSPACE
           ls -a
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           #repository: ibus/ibus
           fetch-depth: 200


### PR DESCRIPTION
Solves the warning in the action run Summary page:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.