### PR TITLE
build: resolve compiler warnings

### DIFF
--- a/src/ibusservice.c
+++ b/src/ibusservice.c
@@ -672,10 +672,8 @@ ibus_service_class_free_interfaces (IBusServiceClass   *class,
 
     g_array_ref (class->interfaces);
     p = interfaces = (GDBusInterfaceInfo **)class->interfaces->data;
-    while (*p != NULL) {
-        *p++;
+    for (; *p != NULL; ++p)
         total++;
-    }
     if (!total)
         return 0;
     if (!depth)


### PR DESCRIPTION
```
$ make V=0
...
  CC       libibus_1_0_la-ibusservice.lo
ibusservice.c: In function 'ibus_service_class_free_interfaces':
ibusservice.c:676:9: warning: value computed is not used [-Wunused-value]
  676 |         *p++;
      |         ^~~~
```

Though `p` is evaluated and used (++), the value of `*(expr)` is not.