### PR TITLE
bus: Fix GetNameOwner reply for org.freedesktop.IBus

### DIFF
--- a/bus/dbusimpl.c
+++ b/bus/dbusimpl.c
@@ -785,9 +785,13 @@ bus_dbus_impl_get_name_owner (BusDBusImpl           *dbus,
     const gchar *name = NULL;
     g_variant_get (parameters, "(&s)", &name);
 
-    if (g_strcmp0 (name, "org.freedesktop.DBus") == 0 ||
-        g_strcmp0 (name, "org.freedesktop.IBus") == 0) {
+    if (g_strcmp0 (name, "org.freedesktop.DBus") == 0) {
+        /* The bus daemon is its own unique name, as per the D-Bus Specification */
         name_owner = name;
+    }
+    else if (g_strcmp0 (name, "org.freedesktop.IBus") == 0) {
+        /* The IBus daemon is always the first connection on the bus */
+        name_owner = ":1.1";
     }
     else {
         BusConnection *owner = bus_dbus_impl_get_connection_by_name (dbus, name);


### PR DESCRIPTION
According to the D-Bus Specification,
`org.freedesktop.DBus.GetNameOwner()` must return a unique name (i.e. one of the form `:1.23`). The only unique name which is allowed to not be in this form is `org.freedesktop.DBus`.

Previously, `ibus-daemon` was returning `org.freedesktop.IBus` when asked for the owner of `org.freedesktop.IBus`. That’s not a valid unique name.

Change how that’s hardcoded to return `:1.1` instead. That’s the first unique name connected to the bus, which will currently always be the `ibus-daemon` itself (and this name won’t disconnect as long as the bus is running).

In the long term, it might be more robust to rework the code so that the mapping from `org.freedesktop.IBus` → a unique name is stored in `dbus->names` (in `dbusimpl.c`) like all the other requested names. However, handling for the `org.freedesktop.IBus` well-known name is hardcoded throughout `dbusimpl.c`, so porting this single bit of it to create a `BusNameService` would probably cause more problems.

I don’t believe that changing the return value of `GetNameOwner` will break anything within ibus.git: the only calls to `GetNameOwner` that I can find are either to query `org.freedesktop.IBus.Config`, or to check whether an owner is set at all (rather than the specific value of the owner).

Signed-off-by: Philip Withnall <pwithnall@gnome.org>

Fixes: #2639