### PR TITLE
src/ibuscomposetable: Fix UFDD5 key for compose seq with fr(bepo_afnor)

### DIFF
--- a/src/ibusenginesimpleprivate.h
+++ b/src/ibusenginesimpleprivate.h
@@ -42,6 +42,7 @@ struct _IBusComposeTablePrivate
 };
 
 
+guint    ibus_compose_key_flag      (guint                       key);
 gboolean ibus_check_algorithmically (const guint                *compose_buffer,
                                      int                         n_compose,
                                      gunichar                   *output);

--- a/src/ibuskeynames.c
+++ b/src/ibuskeynames.c
@@ -47,12 +47,7 @@ ibus_keyval_name (guint keyval)
   static gchar buf[100];
   gdk_key *found;
 
-  /* Check for directly encoded 24-bit UCS characters: */
-  if ((keyval & 0xff000000) == 0x01000000)
-    {
-      g_sprintf (buf, "U+%.04X", (keyval & 0x00ffffff));
-      return buf;
-    }
+  /* <ohorn> with 0x01000000 is supported in gdk_keys_by_keyval */
 
   found = bsearch (&keyval, gdk_keys_by_keyval,
                    IBUS_NUM_KEYS, sizeof (gdk_key),

--- a/src/tests/ibus-compose.basic
+++ b/src/tests/ibus-compose.basic
@@ -8,6 +8,13 @@
 <dead_macron> <U0227>                           : "ǟ"   U01DE
 <Multi_key> <macron> <U0227>                    : "ǟ"   U01DE
 <Multi_key> <underscore> <U0227>                : "ǟ"   U01DE
+# AltGr-t, Shift-asterisk with fr(bepo_afnor) keymap outputs
+# <UFDD5> <0>
+# Support Unicode keysyms in case they are not used in XKB options except
+# for 'Pointer_*' XKB option names.
+<UFDD5> <0> : "⁰" U2070
+#
+### Multibyte chars tests
 # Khmer digraphs
 # This case swaps U17fe and U17ff in en-US
 <U17fe> : "ាំ"
@@ -22,3 +29,6 @@
 # This case swaps c_h and C_h in en-US
 <c_h>   : "C’h"
 <C_h>   : "c’h"
+# Some <U10000> are supported for musical composer in en-US
+<Multi_key> <U1D157> <U1D165>     : "𝇒"   U1D1D2 # MUSICAL SYMBOL SQUARE B
+

--- a/src/tests/ibus-compose.basic
+++ b/src/tests/ibus-compose.basic
@@ -3,7 +3,9 @@
 <Multi_key> <quotedbl> <Cyrillic_zhe>   : "Ӝ"   U04DC
 <Multi_key> <quotedbl> <Cyrillic_ZHE>   : "ӝ"   U04DD
 #
-# Unicode tests of Uxxxx
+# A Unicode keysym <Uxxxx> has a real value 0x01000000 + xxxx.
+# https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/master/include/X11/keysymdef.h?ref_type=heads#L82
+#
 # en-US is "ǡ" U01E1 but this case is "ǟ" U01DE
 <dead_macron> <U0227>                           : "ǟ"   U01DE
 <Multi_key> <macron> <U0227>                    : "ǟ"   U01DE
@@ -13,6 +15,10 @@
 # Support Unicode keysyms in case they are not used in XKB options except
 # for 'Pointer_*' XKB option names.
 <UFDD5> <0> : "⁰" U2070
+# ohorn, grave with vn keymap
+# IBus does not distingish ohorn and Aogonek
+<ohorn> <grave> : "Ờ" U1EDC
+<U01A1> <grave> : "Ờ" U1EDC
 #
 ### Multibyte chars tests
 # Khmer digraphs

--- a/src/tests/ibus-compose.emoji
+++ b/src/tests/ibus-compose.emoji
@@ -1,3 +1,4 @@
+# Emoji tests
 <Multi_key> <Multi_key> <l> <e> <o>             : "♌"  U264C   # LEO
 <Multi_key> <Multi_key> <v> <i> <r> <g> <o>     : "♍"  U264D   # VIRGO
 <Multi_key> <Multi_key> <I> <n> <t>             : "∫"
@@ -9,3 +10,6 @@
 <Multi_key> <Multi_key> <o> <I> <n> <t>         : "∮"
 <Multi_key> <Multi_key> <o> <I> <I> <n> <t>     : "∯"
 <Multi_key> <Multi_key> <o> <I> <I> <I> <n> <t> : "∰"
+# Unicode boundary tests
+<U2800> <0> : "a"
+<braille_blank> <0> : "a"


### PR DESCRIPTION
AltGr-t with fr(bepo_afnor) keymap has no keysym name but can be used in the compose key sequences.
Most Unicode format (UXXXX) should be supported in the compose sequences in case they are not used in XKB options except for 'Pointer_*' XKB option names.

BUG=https://github.com/ibus/ibus/issues/2646
Fixes: https://github.com/ibus/ibus/commit/ad883dc