### PR TITLE
Test big keysyms

### DIFF
--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -1,7 +1,7 @@
 /* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
 /* ibus - The Input Bus
  * Copyright (C) 2013-2014 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2013-2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2013-2024 Takao Fujiwara <takao.fujiwara1@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -615,7 +615,7 @@ ibus_compose_key_flag (guint key)
     /* If name is null, the key sequence is expressed as "<Uxxxx>" format in
      * the Compose file and the typed keysym has the flag.
      */
-    if (!name)
+    if (!name || g_str_has_prefix (name, "0x"))
         return 0x1000000;
     /* "<Pointer_EnableKeys>" is not described in the Compose file but <UFEF9>
      * in the file.

--- a/src/tests/ibus-compose.basic
+++ b/src/tests/ibus-compose.basic
@@ -34,7 +34,7 @@
 # Test Vietnamese (vn layout) symbols
 # https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/c895b24cae5eab27b7ebe45953835da82076c69b/symbols/vn#L30
 <ohorn> <grave> : "Ờ" U1EDC
-<01A1> <grave> : "Ờ" U1EDC
+<U01A1> <grave> : "Ờ" U1EDC
 # Other symbols
 <U2800> <0> : "a"
 <braille_blank> <0> : "a"

--- a/src/tests/ibus-compose.basic
+++ b/src/tests/ibus-compose.basic
@@ -28,3 +28,6 @@
 # for 'Pointer_*' XKB option names.
 <UFDD5> <0> : "⁰"
 
+# Same sequences
+<U2800> <0> : "a"
+<braille_blank> <0> : "a"

--- a/src/tests/ibus-compose.basic
+++ b/src/tests/ibus-compose.basic
@@ -28,6 +28,13 @@
 # for 'Pointer_*' XKB option names.
 <UFDD5> <0> : "⁰"
 
-# Same sequences
+# Same sequences: a Unicode keysym <Uxxxx> has real value 0x01000000 + xxxx.
+# See: https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/68de489ec6c2fb6f8cfc47b0bba7edd0f9942f17/include/X11/keysymdef.h#L82
+
+# Test Vietnamese (vn layout) symbols
+# https://gitlab.freedesktop.org/xkeyboard-config/xkeyboard-config/-/blob/c895b24cae5eab27b7ebe45953835da82076c69b/symbols/vn#L30
+<ohorn> <grave> : "Ờ" U1EDC
+<01A1> <grave> : "Ờ" U1EDC
+# Other symbols
 <U2800> <0> : "a"
 <braille_blank> <0> : "a"

--- a/src/tests/ibus-compose.basic
+++ b/src/tests/ibus-compose.basic
@@ -22,3 +22,9 @@
 # This case swaps c_h and C_h in en-US
 <c_h>   : "C’h"
 <C_h>   : "c’h"
+# AltGr-t, Shift-asterisk with fr(bepo_afnor) keymap outputs
+# <UFDD5> <0>
+# Support Unicode keysyms in case they are not used in XKB options except
+# for 'Pointer_*' XKB option names.
+<UFDD5> <0> : "⁰"
+


### PR DESCRIPTION
Test `<braille_blank>` vs `<U2800>` (same keysym, different syntax).

Relavant quote from [`keysymdef.h`](https://gitlab.freedesktop.org/xorg/proto/xorgproto/-/blob/68de489ec6c2fb6f8cfc47b0bba7edd0f9942f17/include/X11/keysymdef.h#L82):

> For any future extension of the keysyms with characters already
found in ISO 10646 / Unicode, the following algorithm shall be
used. The new keysym code position will simply be the character's
Unicode number plus 0x01000000. The keysym values in the range
0x01000100 to 0x0110ffff are reserved to represent Unicode
characters in the range U+0100 to U+10FFFF.

If IBus supports `<U0100> .. <UFFFF>` it should support _named_ keysyms with _value_ `0x01000100 .. 0x0100ffff`.
