### PR TITLE
ui/gtk3: Fix Super-space in Wayland

### DIFF
--- a/ui/gtk3/keybindingmanager.vala
+++ b/ui/gtk3/keybindingmanager.vala
@@ -60,8 +60,9 @@ public class KeybindingManager : GLib.Object {
     public delegate void KeybindingHandlerFunc(Gdk.Event event);
 
 
-    private  KeybindingManager() {
-        Gdk.Event.handler_set(event_handler);
+    private  KeybindingManager(bool is_wayland_im) {
+        if (!is_wayland_im)
+            Gdk.Event.handler_set(event_handler);
     }
 
     /**
@@ -107,9 +108,9 @@ public class KeybindingManager : GLib.Object {
             m_bindings.remove (binding);
     }
 
-    public static KeybindingManager get_instance () {
+    public static KeybindingManager get_instance (bool is_wayland_im=false) {
         if (m_instance == null)
-            m_instance = new KeybindingManager ();
+            m_instance = new KeybindingManager (is_wayland_im);
         return m_instance;
     }
 

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -446,11 +446,10 @@ class Panel : IBus.PanelService {
     }
 
     private void bind_switch_shortcut() {
-        if (m_is_wayland_im)
-            return;
         string[] accelerators = m_settings_hotkey.get_strv("triggers");
 
-        var keybinding_manager = KeybindingManager.get_instance();
+        var keybinding_manager =
+                KeybindingManager.get_instance(m_is_wayland_im);
 
         BindingCommon.KeyEventFuncType ftype =
                 BindingCommon.KeyEventFuncType.IME_SWITCHER;


### PR DESCRIPTION
ibus_bus_set_global_shortcut_keys_async() was not called in Plasma Wayland after "Fix to unref GdkDisplay in Wayland" patch is applied. Now it's called correctly and the event handler is disabled instead.

BUG=rhbz#2290842
BUG=https://github.com/ibus/ibus/issues/2644
Fixes: https://github.com/ibus/ibus/commit/627e7cc