### PR TITLE
util/IMdkit: Revert to fix typing freeze with barcode reader

### DIFF
--- a/util/IMdkit/i18nPtHdr.c
+++ b/util/IMdkit/i18nPtHdr.c
@@ -1757,7 +1757,6 @@ static void ProcessQueue (XIMS ims, CARD16 connect_id)
         switch (hdr->major_opcode)
         {
         case XIM_FORWARD_EVENT:
-            sync();
             ForwardEventMessageProc(ims, &call_data, p1);
             break;
         }


### PR DESCRIPTION
The original barcode reader issue is fixed with libX11 1.8.10 and it's now available in Fedora.
The typing freezing issue is no longer reproducible with the latest libX11 in Fedora 40.

Now the previous change(b49f3a4736540f3cf2f7e7b3ac7f965970393c74) is reverted and I continue to trace the issue.

Fixes: https://github.com/ibus/ibus/commit/b49f3a4 BUG=https://gitlab.freedesktop.org/xorg/lib/libx11/-/issues/198 BUG=https://github.com/ibus/ibus/issues/2560