### PR TITLE
src/ibuscomposetable: Replace obsolete index(3) with strchr(3).

### DIFF
--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -192,7 +192,7 @@ parse_compose_sequence (IBusComposeData *compose_data,
 
     for (i = 1; words[i] != NULL; i++) {
         char *start = words[i];
-        char *end = index (words[i], '>');
+        char *end = strchr (words[i], '>');
         char *match;
         gunichar codepoint;
 


### PR DESCRIPTION
index(3) has been obsolete
https://pubs.opengroup.org/onlinepubs/009695399/functions/index.html
and it also requires `<strings.h>` but the include was removed in https://github.com/ibus/ibus/commit/706ba01504a0c48391360a236d7c7aa8e0057753