### PR TITLE
Fix memory leak of IBusText in ibus_input_context_set_surrounding_text

### DIFF
--- a/src/ibusinputcontext.c
+++ b/src/ibusinputcontext.c
@@ -1168,6 +1168,8 @@ ibus_input_context_set_surrounding_text (IBusInputContext   *context,
                                 NULL                        /* user_data */
                                 );
         }
+    } else {
+       g_object_unref(text);
     }
 }
 


### PR DESCRIPTION
ASAN is warning of a memory leak of a IBusText:
```
Direct leak of 208 byte(s) in 2 object(s) allocated from:
    #0 0x55c766175899 in calloc /tmp/final/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:75:3
    #1 0x7f2cbe5e47a1 in g_malloc0 (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x637a1) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #2 0x7f2cbe70af65 in g_type_create_instance (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x40f65) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #3 0x7f2cbe6f09c9  (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x269c9) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #4 0x7f2cbe6f0690  (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x26690) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #5 0x7f2cbe6f1fc3 in g_object_new_with_properties (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x27fc3) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #6 0x7f2cbe6f2f70 in g_object_new (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x28f70) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #7 0x7f2c9e1c2853 in ibus_text_new_from_string (/lib/x86_64-linux-gnu/libibus-1.0.so.5+0x45853) (BuildId: 7beb1c25d18ef14776886ce2e5281bcc983ae580)
    #8 0x7f2ca0e21227  (/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-ibus.so+0x6227) (BuildId: 9d71251e5d8cf26f31f30732e5c9b03af45dc945)
    #9 0x7f2ca0e2138d  (/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-ibus.so+0x638d) (BuildId: 9d71251e5d8cf26f31f30732e5c9b03af45dc945)

Indirect leak of 2 byte(s) in 2 object(s) allocated from:
    #0 0x55c7661756cf in malloc /tmp/final/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:68:3
    #1 0x7f2cbe5e3af9 in g_malloc (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x62af9) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #2 0x7f2cbe5f94c8 in g_strdup (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x784c8) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #3 0x7f2c9e1c2865 in ibus_text_new_from_string (/lib/x86_64-linux-gnu/libibus-1.0.so.5+0x45865) (BuildId: 7beb1c25d18ef14776886ce2e5281bcc983ae580)
    #4 0x7f2ca0e21227  (/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-ibus.so+0x6227) (BuildId: 9d71251e5d8cf26f31f30732e5c9b03af45dc945)
    #5 0x7f2ca0e213d4  (/usr/lib/x86_64-linux-gnu/gtk-3.0/3.0.0/immodules/im-ibus.so+0x63d4) (BuildId: 9d71251e5d8cf26f31f30732e5c9b03af45dc945)
    #6 0x7f2cab89d0a3  (/lib/x86_64-linux-gnu/libgtk-3.so+0x9d0a3) (BuildId: 69b071aa172bf1183dd44deab21edf15f29a2045)
    #7 0x7f2cbe6df2f9 in g_closure_invoke (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x152f9) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #8 0x7f2cbe70e90b  (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x4490b) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #9 0x7f2cbe6feef1  (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x34ef1) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #10 0x7f2cbe6ff7c0 in g_signal_emit_valist (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x357c0) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #11 0x7f2cbe6ff882 in g_signal_emit (/lib/x86_64-linux-gnu/libgobject-2.0.so.0+0x35882) (BuildId: e9a3264635c0eb3b5f6b3201084e8e59d5b18083)
    #12 0x7f2cabb66b63  (/lib/x86_64-linux-gnu/libgtk-3.so+0x366b63) (BuildId: 69b071aa172bf1183dd44deab21edf15f29a2045)
    #13 0x7f2caba0330f  (/lib/x86_64-linux-gnu/libgtk-3.so+0x20330f) (BuildId: 69b071aa172bf1183dd44deab21edf15f29a2045)
    #14 0x7f2caba03ea9 in gtk_main_do_event (/lib/x86_64-linux-gnu/libgtk-3.so+0x203ea9) (BuildId: 69b071aa172bf1183dd44deab21edf15f29a2045)
    #15 0x7f2cae73f406  (/lib/x86_64-linux-gnu/libgdk-3.so+0x3a406) (BuildId: 5638978eaf26c38c9a3341d93fae1aa9d94de18a)
    #16 0x7f2cae798c6d  (/lib/x86_64-linux-gnu/libgdk-3.so+0x93c6d) (BuildId: 5638978eaf26c38c9a3341d93fae1aa9d94de18a)
    #17 0x7f2cbe5de5b4  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5d5b4) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #18 0x7f2cbe63d716  (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0xbc716) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
    #19 0x7f2cbe5def76 in g_main_loop_run (/lib/x86_64-linux-gnu/libglib-2.0.so.0+0x5df76) (BuildId: 9753724b85d60f97b5d5663181ef7f4e69a62131)
```

Looking at `ibus_im_context_set_surrounding_with_selection` a `IBusText` is allocated and passed to `ibus_input_context_set_surrounding_text`, which then possibly ignores it entirely. This results in a leak.

The fix is that either `ibus_im_context_set_surrounding_with_selection` must not pass a floating reference and call `g_object_unref`, or `ibus_input_context_set_surrounding_text` must take ownership of the passed reference and call `g_object_unref` if the text is not used.