### PR TITLE
Correct Parent Class Reference in ibus_unicode_block_destroy Function

### DIFF
--- a/src/ibusunicode.c
+++ b/src/ibusunicode.c
@@ -759,7 +759,7 @@ ibus_unicode_block_destroy (IBusUnicodeBlock *block)
 {
     g_clear_pointer (&block->priv->name, g_free);
 
-    IBUS_OBJECT_CLASS (ibus_unicode_data_parent_class)->
+    IBUS_OBJECT_CLASS (ibus_unicode_block_parent_class)->
             destroy (IBUS_OBJECT (block));
 }
 


### PR DESCRIPTION
The function `ibus_unicode_block_destroy` was incorrectly using the parent class of `IBusUnicodeData`. Since this function is for the `IBusUnicodeBlock` class, the correct parent class should be `ibus_unicode_block_parent_class`