### PR TITLE
src/tests: Use dbus_try_get_local_machine_id() in ibus-share

### DIFF
--- a/src/tests/ibus-share.c
+++ b/src/tests/ibus-share.c
@@ -4,10 +4,17 @@
 static void
 test_machine_id (void)
 {
+    DBusError error = DBUS_ERROR_INIT;
     const gchar *s1 = ibus_get_local_machine_id ();
-    gchar *s2 = dbus_get_local_machine_id ();
+    gchar *s2 = dbus_try_get_local_machine_id (&error);
 
-    g_assert_cmpstr (s1, ==, s2);
+    g_assert (s1);
+    if (!s2) {
+        g_error ("Failed to get the local machine id: %s: %s",
+                 error.name, error.message);
+    } else {
+        g_assert_cmpstr (s1, ==, s2);
+    }
     dbus_free (s2);
 }
 


### PR DESCRIPTION
Replace dbus_get_local_machine_id() with dbus_try_get_local_machine_id() to retrieve the DBUsError.

BUG=https://github.com/ibus/ibus/issues/2686