### PR TITLE
IBus compose enhancement to GTK4

### DIFF
--- a/src/gencomposetable.c
+++ b/src/gencomposetable.c
@@ -1,8 +1,8 @@
 /* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
- * Copyright (C) 2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -76,6 +76,7 @@ main (int argc, char *argv[])
     char * const *sys_lang = NULL;
     char *path = NULL;
     IBusComposeTableEx *compose_table;
+    guint16 saved_version = 0;
     char *basename = NULL;
 
     path = g_strdup ("./Compose");
@@ -97,13 +98,15 @@ main (int argc, char *argv[])
         g_debug ("Create a cache of %s", path);
     }
     g_setenv ("IBUS_COMPOSE_CACHE_DIR", ".", TRUE);
-    compose_table = ibus_compose_table_load_cache (path);
+    compose_table = ibus_compose_table_load_cache (path, &saved_version);
     if (!compose_table &&
         (compose_table = ibus_compose_table_new_with_file (path, NULL))
            == NULL) {
         g_warning ("Failed to generate the compose table.");
         return 1;
     }
+    if (saved_version > 0)
+        g_warning ("Old cache was updated.");
     g_free (path);
     basename = g_strdup_printf ("%08x.cache", compose_table->id);
     g_debug ("Saving cache id %s", basename);

--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -1,7 +1,7 @@
 /* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
 /* ibus - The Input Bus
  * Copyright (C) 2013-2014 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2013-2024 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2013-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -38,7 +38,7 @@
 
 
 #define IBUS_COMPOSE_TABLE_MAGIC "IBusComposeTable"
-#define IBUS_COMPOSE_TABLE_VERSION (4)
+#define IBUS_COMPOSE_TABLE_VERSION (5)
 #define IBUS_MAX_COMPOSE_ALGORITHM_LEN 9
 
 typedef struct {
@@ -283,10 +283,15 @@ expand_include_path (const char *include_path) {
                 break;
             }
             case 'L': /* locale compose file */
-                g_warning ("while handling XCompose include target %s, found "
-                          "redundant %%L include; the include has been "
-                          "ignored", include_path);
-                goto fail;
+                out = g_strdup ("%L");
+                head = i + 2;
+                while (*head || *head == ' ' || *head == '\t') head++;
+                if (*head != '\0') {
+                    g_warning ("\"%s\" after \"%%L\" is not supported in "
+                               "XCompose include target.", head);
+                    goto fail;
+                }
+                break;
             case 'S': /* system compose dir */
                 o = out;
                 former = g_strndup (head, i - head);
@@ -413,7 +418,8 @@ get_en_compose_file (void)
 
 static GList *
 ibus_compose_list_parse_file (const char *compose_file,
-                              int        *max_compose_len)
+                              int        *max_compose_len,
+                              gboolean   *can_load_en_us)
 {
     char *contents = NULL;
     char **lines = NULL;
@@ -423,6 +429,7 @@ ibus_compose_list_parse_file (const char *compose_file,
     int i;
 
     g_assert (max_compose_len);
+    g_assert (can_load_en_us);
 
     if (!g_file_get_contents (compose_file, &contents, &length, &error)) {
         g_error ("%s", error->message);
@@ -438,6 +445,11 @@ ibus_compose_list_parse_file (const char *compose_file,
         parse_compose_line (&compose_list, lines[i], &compose_len, &include);
         if (*max_compose_len < compose_len)
             *max_compose_len = compose_len;
+        if (!g_strcmp0 (include, "%L")) {
+            *can_load_en_us = TRUE;
+            g_clear_pointer (&include, g_free);
+            continue;
+        }
         if (include && *include) {
             GStatBuf buf_include = { 0, };
             GStatBuf buf_parent = { 0, };
@@ -486,7 +498,8 @@ ibus_compose_list_parse_file (const char *compose_file,
         if (include && *include) {
             GList *rest = ibus_compose_list_parse_file (
                     include,
-                    max_compose_len);
+                    max_compose_len,
+                    can_load_en_us);
             if (rest) {
                 compose_list = g_list_concat (compose_list, rest);
             }
@@ -504,13 +517,16 @@ ibus_compose_list_check_duplicated_with_en (GList  *compose_list,
                                             int     max_compose_len,
                                             GSList *compose_tables)
 {
+    guint *keysyms;
+    GString *output;
     GList *list;
-    static guint *keysyms;
     GList *removed_list = NULL;
     IBusComposeData *compose_data;
-    GString *output = g_string_new ("");
 
+    if (!compose_list)
+        return NULL;
     keysyms = g_new (guint, max_compose_len + 1);
+    output = g_string_new ("");
 
     for (list = compose_list; list != NULL; list = list->next) {
         int i;
@@ -694,6 +710,8 @@ ibus_compose_list_check_duplicated_with_own (GList  *compose_list,
     int i;
     GList *removed_list = NULL;
 
+    if (!compose_list)
+        return NULL;
     for (list = compose_list; list != NULL; list = list->next) {
         gboolean is_different_value = FALSE;
         if (!list->next)
@@ -921,6 +939,7 @@ ibus_compose_table_serialize (IBusComposeTableEx *compose_table,
     guint16 max_seq_len;
     guint16 index_stride;
     guint16 n_seqs;
+    guint8 compose_type = 0;
     gsize n_seqs_32bit = 0;
     gsize second_size = 0;
     GVariant *variant_data = NULL;
@@ -934,8 +953,9 @@ ibus_compose_table_serialize (IBusComposeTableEx *compose_table,
     max_seq_len = compose_table->max_seq_len;
     index_stride = max_seq_len + 2;
     n_seqs = compose_table->n_seqs;
+    compose_type = compose_table->can_load_en_us ? 1 : 0;
 
-    g_return_val_if_fail (max_seq_len, NULL);
+    g_return_val_if_fail (max_seq_len || compose_type, NULL);
 
     if (n_seqs) {
         g_return_val_if_fail (compose_table->data, NULL);
@@ -965,7 +985,7 @@ ibus_compose_table_serialize (IBusComposeTableEx *compose_table,
         n_seqs_32bit = compose_table->priv->first_n_seqs;
         second_size = compose_table->priv->second_size;
     }
-    if (!n_seqs && !n_seqs_32bit) {
+    if (!n_seqs && !n_seqs_32bit && !compose_type) {
         g_warning ("ComposeTable has not key sequences.");
         goto out_serialize;
     } else if (n_seqs_32bit && !second_size) {
@@ -1028,7 +1048,7 @@ ibus_compose_table_serialize (IBusComposeTableEx *compose_table,
                 sizeof (guint32));
         g_assert (variant_data_32bit_first && variant_data_32bit_second);
     }
-    variant_table = g_variant_new ("(sqqqqqvvv)",
+    variant_table = g_variant_new ("(sqqqqqvvvy)",
                                    header,
                                    version,
                                    max_seq_len,
@@ -1037,7 +1057,8 @@ ibus_compose_table_serialize (IBusComposeTableEx *compose_table,
                                    second_size,
                                    variant_data,
                                    variant_data_32bit_first,
-                                   variant_data_32bit_second);
+                                   variant_data_32bit_second,
+                                   compose_type);
     return g_variant_ref_sink (variant_table);
 
 out_serialize:
@@ -1062,7 +1083,7 @@ ibus_compose_table_find (gconstpointer data1,
 IBusComposeTableEx *
 ibus_compose_table_deserialize (const char *contents,
                                 gsize       length,
-                                gboolean    reverse_endianness)
+                                guint16    *saved_version)
 {
     IBusComposeTableEx *retval = NULL;
     GVariantType *type;
@@ -1071,9 +1092,9 @@ ibus_compose_table_deserialize (const char *contents,
     GVariant *variant_data_32bit_second = NULL;
     GVariant *variant_table = NULL;
     const char *header = NULL;
-    guint16 version = 0;
     guint16 max_seq_len = 0;
     guint16 n_seqs = 0;
+    guint8 compose_type = 0;
     guint16 n_seqs_32bit = 0;
     guint16 second_size = 0;
     guint16 index_stride;
@@ -1084,7 +1105,9 @@ ibus_compose_table_deserialize (const char *contents,
 
     g_return_val_if_fail (contents != NULL, NULL);
     g_return_val_if_fail (length > 0, NULL);
+    g_assert (saved_version);
 
+    *saved_version = 0;
     /* Check the cache version at first before load whole the file content. */
     type = g_variant_type_new ("(sq)");
     variant_table = g_variant_new_from_data (type,
@@ -1101,25 +1124,24 @@ ibus_compose_table_deserialize (const char *contents,
     }
 
     g_variant_ref_sink (variant_table);
-    g_variant_get (variant_table, "(&sq)", &header, &version);
+    g_variant_get (variant_table, "(&sq)", &header, saved_version);
 
     if (g_strcmp0 (header, IBUS_COMPOSE_TABLE_MAGIC) != 0) {
         g_warning ("cache is not IBusComposeTable.");
         goto out_load_cache;
     }
 
-    if (version != IBUS_COMPOSE_TABLE_VERSION) {
+    if (*saved_version != IBUS_COMPOSE_TABLE_VERSION) {
         g_warning ("cache version is different: %u != %u",
-                   version, IBUS_COMPOSE_TABLE_VERSION);
+                   *saved_version, IBUS_COMPOSE_TABLE_VERSION);
         goto out_load_cache;
     }
 
-    version = 0;
     header = NULL;
     g_variant_unref (variant_table);
     variant_table = NULL;
 
-    type = g_variant_type_new ("(sqqqqqvvv)");
+    type = g_variant_type_new ("(sqqqqqvvvy)");
     variant_table = g_variant_new_from_data (type,
                                              contents,
                                              length,
@@ -1134,7 +1156,7 @@ ibus_compose_table_deserialize (const char *contents,
     }
 
     g_variant_ref_sink (variant_table);
-    g_variant_get (variant_table, "(&sqqqqqvvv)",
+    g_variant_get (variant_table, "(&sqqqqqvvvy)",
                    NULL,
                    NULL,
                    &max_seq_len,
@@ -1143,12 +1165,15 @@ ibus_compose_table_deserialize (const char *contents,
                    &second_size,
                    &variant_data,
                    &variant_data_32bit_first,
-                   &variant_data_32bit_second);
+                   &variant_data_32bit_second,
+                   &compose_type);
 
     if (max_seq_len == 0 || (n_seqs == 0 && n_seqs_32bit == 0)) {
-        g_warning ("cache size is not correct %d %d %d",
-                   max_seq_len, n_seqs, n_seqs_32bit);
-        goto out_load_cache;
+        if (!compose_type) {
+            g_warning ("cache size is not correct %d %d %d",
+                       max_seq_len, n_seqs, n_seqs_32bit);
+            goto out_load_cache;
+        }
     }
 
     if (n_seqs && variant_data) {
@@ -1169,6 +1194,7 @@ ibus_compose_table_deserialize (const char *contents,
         retval->data = data;
     retval->max_seq_len = max_seq_len;
     retval->n_seqs = n_seqs;
+    retval->can_load_en_us = compose_type ? TRUE : FALSE;
 
     if (n_seqs_32bit && !second_size) {
         g_warning ("32bit key sequences are loaded but the values " \
@@ -1193,7 +1219,7 @@ ibus_compose_table_deserialize (const char *contents,
             goto out_load_cache;
         }
     }
-    if (!data && !data_32bit_first) {
+    if (!data && !data_32bit_first && !compose_type) {
         g_warning ("cache data is null.");
         goto out_load_cache;
     }
@@ -1236,7 +1262,8 @@ out_load_cache:
 
 
 IBusComposeTableEx *
-ibus_compose_table_load_cache (const gchar *compose_file)
+ibus_compose_table_load_cache (const gchar *compose_file,
+                               guint16     *saved_version)
 {
     IBusComposeTableEx *retval = NULL;
     guint32 hash;
@@ -1247,6 +1274,8 @@ ibus_compose_table_load_cache (const gchar *compose_file)
     gsize length = 0;
     GError *error = NULL;
 
+    g_assert (saved_version);
+    *saved_version = 0;
     do {
         hash = g_str_hash (compose_file);
         if ((path = ibus_compose_hash_get_cache_path (hash)) == NULL)
@@ -1271,7 +1300,9 @@ ibus_compose_table_load_cache (const gchar *compose_file)
             break;
         }
 
-        retval = ibus_compose_table_deserialize (contents, length, FALSE);
+        retval = ibus_compose_table_deserialize (contents,
+                                                 length,
+                                                 saved_version);
         if (retval == NULL) {
             g_warning ("Failed to load the cache file: %s", path);
         } else {
@@ -1370,7 +1401,7 @@ ibus_compose_table_new_with_list (GList   *compose_list,
     IBusComposeData *compose_data = NULL;
     IBusComposeTableEx *retval = NULL;
 
-    g_return_val_if_fail (compose_list != NULL, NULL);
+    g_return_val_if_fail (compose_list, NULL);
 
     s_size_total = g_list_length (compose_list);
     s_size_16bit = s_size_total;
@@ -1499,6 +1530,7 @@ ibus_compose_table_new_with_list (GList   *compose_list,
     retval->n_seqs = s_size_16bit;
     retval->id = hash;
     retval->rawdata = rawdata;
+    retval->can_load_en_us = FALSE;
     if (s_size_total > s_size_16bit) {
         retval->priv = g_new0 (IBusComposeTablePrivate, 1);
         retval->priv->data_first = ibus_compose_seqs_32bit_first;
@@ -1516,6 +1548,8 @@ ibus_compose_table_new_with_file (const gchar *compose_file,
                                   GSList      *compose_tables)
 {
     GList *compose_list = NULL;
+    gboolean can_load_en_us = FALSE;
+    gboolean can_load_en_us_by_any = FALSE;
     IBusComposeTableEx *compose_table;
     int max_compose_len = 0;
     int n_index_stride = 0;
@@ -1523,13 +1557,29 @@ ibus_compose_table_new_with_file (const gchar *compose_file,
     g_assert (compose_file != NULL);
 
     compose_list = ibus_compose_list_parse_file (compose_file,
-                                                 &max_compose_len);
-    if (compose_list == NULL)
+                                                 &max_compose_len,
+                                                 &can_load_en_us);
+    if (compose_list == NULL && !can_load_en_us)
         return NULL;
     n_index_stride = max_compose_len + 2;
-    compose_list = ibus_compose_list_check_duplicated_with_en (compose_list,
-                                                               max_compose_len,
-                                                               compose_tables);
+    can_load_en_us_by_any = can_load_en_us;
+    if (!can_load_en_us_by_any) {
+        GSList *l = compose_tables;
+        while (l) {
+            IBusComposeTableEx *table = l->data;
+            if (table->can_load_en_us) {
+                can_load_en_us_by_any = TRUE;
+                break;
+            }
+            l = l->next;
+        }
+    }
+    if (can_load_en_us_by_any) {
+        compose_list = ibus_compose_list_check_duplicated_with_en (
+                compose_list,
+                max_compose_len,
+                compose_tables);
+    }
     compose_list = g_list_sort_with_data (
             compose_list,
             (GCompareDataFunc) ibus_compose_data_compare,
@@ -1540,8 +1590,18 @@ ibus_compose_table_new_with_file (const gchar *compose_file,
             max_compose_len);
 
     if (compose_list == NULL) {
-        g_warning ("compose file %s does not include any keys besides keys "
-                   "in en-us compose file", compose_file);
+        g_message ("compose file %s does not include any keys besides keys "
+                   "in en-us compose file.\n", compose_file);
+        if (can_load_en_us) {
+            if (!(compose_table = g_new0 (IBusComposeTableEx, 1))) {
+                g_warning ("Failed to alloc IBusComposeTableEx for %s.",
+                            compose_file);
+            } else {
+                compose_table->id = g_str_hash (compose_file);
+                compose_table->can_load_en_us = can_load_en_us;
+                return compose_table;
+            }
+        }
         return NULL;
     }
 
@@ -1553,11 +1613,80 @@ ibus_compose_table_new_with_file (const gchar *compose_file,
             max_compose_len,
             n_index_stride,
             g_str_hash (compose_file));
+    if (compose_table)
+        compose_table->can_load_en_us = can_load_en_us;
 
     g_list_free_full (compose_list,
                       (GDestroyNotify) ibus_compose_list_element_free);
 
     return compose_table;
+}
+
+
+void
+ibus_compose_table_free (IBusComposeTableEx *compose_table)
+{
+    g_return_if_fail (compose_table);
+    g_clear_pointer (&compose_table->priv, g_free);
+    compose_table->data = NULL;
+    compose_table->max_seq_len = 0;
+    compose_table->n_seqs = 0;
+    compose_table->id = 0;
+    g_clear_pointer (&compose_table->rawdata, g_free);
+    compose_table->can_load_en_us = FALSE;
+    g_free (compose_table);
+
+}
+
+
+static gboolean
+rewrite_compose_file (const char *compose_file)
+{
+    static const char *prefix =
+            "# IBus has rewritten this file to add the line:\n"
+            "\n"
+            "include \"%L\"\n"
+            "\n"
+            "# This is necessary to add your own Compose sequences\n"
+            "# in addition to the builtin sequences of IBus. If this\n"
+            "# is not what you want, just remove that line.\n"
+            "#\n"
+            "# A backup of the previous file contents has been made.\n"
+            "\n"
+            "\n";
+
+    char *content = NULL;
+    gsize content_len;
+    GFile *file = NULL;
+    GOutputStream *stream = NULL;
+    gboolean ret = FALSE;
+
+    if (!g_file_get_contents (compose_file, &content, &content_len, NULL))
+        goto out;
+
+    file = g_file_new_for_path (compose_file);
+    stream = G_OUTPUT_STREAM (g_file_replace (file, NULL, TRUE, 0, NULL, NULL));
+
+    if (stream == NULL)
+        goto out;
+
+    if (!g_output_stream_write (stream, prefix, strlen (prefix), NULL, NULL))
+        goto out;
+
+    if (!g_output_stream_write (stream, content, content_len, NULL, NULL))
+        goto out;
+
+    if (!g_output_stream_close (stream, NULL, NULL))
+        goto out;
+
+    ret = TRUE;
+
+out:
+    g_clear_object (&stream);
+    g_clear_object (&file);
+    g_clear_pointer (&content, g_free);
+
+    return ret;
 }
 
 
@@ -1614,6 +1743,7 @@ ibus_compose_table_list_add_file (GSList      *compose_tables,
 {
     guint32 hash;
     IBusComposeTableEx *compose_table;
+    guint16 saved_version = 0;
 
     g_return_val_if_fail (compose_file != NULL, compose_tables);
 
@@ -1624,15 +1754,42 @@ ibus_compose_table_list_add_file (GSList      *compose_tables,
         return compose_tables;
     }
 
-    compose_table = ibus_compose_table_load_cache (compose_file);
+    compose_table = ibus_compose_table_load_cache (compose_file,
+                                                   &saved_version);
     if (compose_table != NULL)
         return g_slist_prepend (compose_tables, compose_table);
 
-   if ((compose_table = ibus_compose_table_new_with_file (compose_file,
+parse:
+    if ((compose_table = ibus_compose_table_new_with_file (compose_file,
                                                           compose_tables))
            == NULL) {
-       return compose_tables;
-   }
+        return compose_tables;
+    }
+    if (saved_version > 0 && saved_version < 5 &&
+        !compose_table->can_load_en_us && compose_table->n_seqs < 100) {
+        if (rewrite_compose_file (compose_file)) {
+            g_warning ("\nSince IBus 1.5.32, Compose files replace the "
+                       "builtin\n"
+                       "compose sequences. To keep them and add your own\n"
+                       "sequences on top, the line:\n"
+                       "\n"
+                       "  include \"%%L\"\n"
+                       "\n"
+                       "has been added to the Compose file:\n%s.\n",
+                       compose_file);
+            ibus_compose_table_free (compose_table);
+            goto parse;
+        } else {
+            g_warning ("\nSince IBus 1.5.32, Compose files replace the "
+                       "builtin\n"
+                       "compose sequences. To keep them and add your own\n"
+                       "sequences on top, you need to add the line:\n"
+                       "\n"
+                       "  include \"%%L\"\n"
+                       "\n"
+                       "to the Compose file:\n%s.\n", compose_file);
+        }
+    }
 
     ibus_compose_table_save_cache (compose_table);
     return g_slist_prepend (compose_tables, compose_table);

--- a/src/ibuscomposetable.h
+++ b/src/ibuscomposetable.h
@@ -53,6 +53,7 @@ struct _IBusComposeTableEx
     gint n_seqs;
     guint32 id;
     char *rawdata;
+    gboolean can_load_en_us;
 };
 
 
@@ -71,8 +72,12 @@ IBusComposeTableEx *
                   ibus_compose_table_new_with_file (const gchar *compose_file,
                                                     GSList
                                                                *compose_tables);
+void               ibus_compose_table_free         (IBusComposeTableEx
+                                                                *compose_table);
 IBusComposeTableEx *
-                  ibus_compose_table_load_cache    (const gchar *compose_file);
+                  ibus_compose_table_load_cache    (const gchar *compose_file,
+                                                    guint16     *saved_version);
+
 void              ibus_compose_table_save_cache    (IBusComposeTableEx
                                                                 *compose_table);
 GSList *          ibus_compose_table_list_add_array

--- a/src/ibusenginesimple.c
+++ b/src/ibusenginesimple.c
@@ -2,7 +2,7 @@
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
  * Copyright (C) 2014 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2015-2024 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2015-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
  * Copyright (C) 2014-2017 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -676,7 +676,7 @@ no_sequence_matches (IBusEngineSimple *simple,
         priv->compose_buffer[0] = 0;
         if (n_compose > 1) {
             /* Invalid sequence */
-            // FIXME beep_window (event->window);
+            /* FIXME beep_window (event->window); */
             ibus_engine_simple_update_preedit_text (simple);
             return TRUE;
         }
@@ -914,6 +914,7 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
     IBusEngineSimple *simple = (IBusEngineSimple *)engine;
     IBusEngineSimplePrivate *priv = simple->priv;
     int n_compose = 0;
+    int n_compose_prev;
     gboolean have_hex_mods;
     gboolean is_hex_start = FALSE;
     gboolean is_emoji_start = FALSE;
@@ -931,6 +932,7 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
         g_warning ("copmose table buffer is full.");
         n_compose = COMPOSE_BUFFER_SIZE;
     }
+    n_compose_prev = n_compose;
 
     if (modifiers & IBUS_RELEASE_MASK) {
         if (priv->in_hex_sequence &&
@@ -1013,10 +1015,11 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
         (priv->in_hex_sequence || priv->in_emoji_sequence)) {
         if (is_backspace) {
             priv->compose_buffer[--n_compose] = 0;
+            n_compose_prev = n_compose;
         }
         else if (is_hex_end) {
             /* invalid hex sequence */
-            // beep_window (event->window);
+            /* FIXME beep_window (event->window); */
             g_string_set_size (priv->tentative_match, 0);
             g_clear_pointer (&priv->tentative_emoji, g_free);
             priv->in_hex_sequence = FALSE;
@@ -1068,8 +1071,8 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
     /* Handle backspace */
     if (priv->in_hex_sequence && have_hex_mods && is_backspace) {
         if (n_compose > 0) {
-            n_compose--;
-            priv->compose_buffer[n_compose] = 0;
+            priv->compose_buffer[--n_compose] = 0;
+            n_compose_prev = n_compose;
             check_hex (simple, n_compose);
         } else {
             priv->in_hex_sequence = FALSE;
@@ -1081,8 +1084,8 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
     }
     if (priv->in_emoji_sequence && have_hex_mods && is_backspace) {
         if (n_compose > 0) {
-            n_compose--;
-            priv->compose_buffer[n_compose] = 0;
+            priv->compose_buffer[--n_compose] = 0;
+            n_compose_prev = n_compose;
             check_emoji_table (simple, n_compose, -1);
             ibus_engine_simple_update_lookup_and_aux_table (simple);
         } else {
@@ -1095,8 +1098,8 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
     }
     if (!priv->in_hex_sequence && !priv->in_emoji_sequence && is_backspace) {
         if (n_compose > 0) {
-            n_compose--;
-            priv->compose_buffer[n_compose] = 0;
+            priv->compose_buffer[--n_compose] = 0;
+            n_compose_prev = n_compose;
             g_string_set_size (priv->tentative_match, 0);
             priv->tentative_match_len = 0;
             ibus_engine_simple_check_all_compose_table (simple, n_compose);
@@ -1115,7 +1118,7 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
         else {
             /* invalid hex sequence */
             if (n_compose > 0) {
-                // FIXME beep_window (event->window);
+                /* FIXME beep_window (event->window); */
                 g_string_set_size (priv->tentative_match, 0);
                 priv->in_hex_sequence = FALSE;
                 priv->compose_buffer[0] = 0;
@@ -1179,9 +1182,8 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
 
             return TRUE;
         } else if (!is_hex_end) {
-            // FIXME
             /* non-hex character in hex sequence */
-            // beep_window (event->window);
+            /* FIXME beep_window (event->window); */
             return TRUE;
         }
     } else if (priv->in_emoji_sequence) {
@@ -1239,17 +1241,15 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
                     ibus_engine_simple_update_preedit_text (simple);
                     return TRUE;
                 } else {
-                    // FIXME
                     /* invalid hex sequence */
-                    // beep_window (event->window);
+                    /* FIXME beep_window (event->window); */
                     g_string_set_size (priv->tentative_match, 0);
                     priv->in_hex_sequence = FALSE;
                     priv->compose_buffer[0] = 0;
                 }
             }
             else if (!check_hex (simple, n_compose))
-                // FIXME
-                // beep_window (event->window);
+                /* FIXME beep_window (event->window); */
                 ;
             ibus_engine_simple_update_preedit_text (simple);
 
@@ -1334,8 +1334,21 @@ ibus_engine_simple_process_key_event (IBusEngine *engine,
             return TRUE;
         }
     } else { /* Then, check for compose sequences */
-        if (ibus_engine_simple_check_all_compose_table (simple, n_compose))
+        if (ibus_engine_simple_check_all_compose_table (simple, n_compose)) {
             return TRUE;
+        } else if (n_compose_prev > 0 && (n_compose - n_compose_prev) > 0) {
+            /* Show the previous preedit text. */
+            guint backup_char = 0;
+
+            n_compose = n_compose_prev;
+            g_assert (n_compose < (COMPOSE_BUFFER_SIZE + 1));
+            /* FIXME beep_window (event->window); */
+            backup_char = priv->compose_buffer[n_compose];
+            priv->compose_buffer[n_compose] = 0;
+            if (ibus_engine_simple_check_all_compose_table (simple, n_compose))
+                return TRUE;
+            priv->compose_buffer[n_compose] = backup_char;
+        }
     }
 
     /* The current compose_buffer doesn't match anything */
@@ -1529,4 +1542,3 @@ ibus_engine_simple_add_compose_file (IBusEngineSimple *simple,
                                                       compose_file);
     return TRUE;
 }
-

--- a/src/ibusenginesimple.c
+++ b/src/ibusenginesimple.c
@@ -90,6 +90,7 @@ guint COMPOSE_BUFFER_SIZE = 20;
 G_LOCK_DEFINE_STATIC (global_tables);
 static GSList *global_tables;
 static IBusText *updated_preedit_empty;
+static IBusComposeTableEx *en_compose_table;
 
 /* functions prototype */
 static void     ibus_engine_simple_destroy      (IBusEngineSimple   *simple);
@@ -124,6 +125,11 @@ ibus_engine_simple_class_init (IBusEngineSimpleClass *class)
 {
     IBusObjectClass *ibus_object_class = IBUS_OBJECT_CLASS (class);
     IBusEngineClass *engine_class = IBUS_ENGINE_CLASS (class);
+    GBytes *data;
+    GError *error = NULL;
+    const char *contents;
+    gsize length = 0;
+    guint16 saved_version = 0;
 
     ibus_object_class->destroy =
         (IBusObjectDestroyFunc) ibus_engine_simple_destroy;
@@ -139,17 +145,31 @@ ibus_engine_simple_class_init (IBusEngineSimpleClass *class)
                             = ibus_engine_simple_candidate_clicked;
     updated_preedit_empty = ibus_text_new_from_string ("");
     g_object_ref_sink (updated_preedit_empty);
+
+    data = g_resources_lookup_data ("/org/freedesktop/ibus/compose/sequences",
+                                    G_RESOURCE_LOOKUP_FLAGS_NONE,
+                                    &error);
+    if (error) {
+        g_warning ("Not found compose resource %s", error->message);
+        g_clear_error (&error);
+        return;
+    }
+    contents = g_bytes_get_data (data, &length);
+    en_compose_table = ibus_compose_table_deserialize (contents,
+                                                       length,
+                                                       &saved_version);
+    if (!en_compose_table && saved_version) {
+        g_warning ("Failed to parse the builtin compose due to the different "
+                   "version %u. Please rebuild IBus resource files.",
+                   saved_version);
+    }
 }
+
 
 static void
 ibus_engine_simple_init (IBusEngineSimple *simple)
 {
     IBusEngineSimplePrivate *priv;
-    GBytes *data;
-    GError *error = NULL;
-    const char *contents;
-    gsize length = 0;
-    IBusComposeTableEx *en_compose_table;
 
     priv = simple->priv = IBUS_ENGINE_SIMPLE_GET_PRIVATE (simple);
     priv->compose_buffer = g_new0 (guint, COMPOSE_BUFFER_SIZE + 1);
@@ -160,16 +180,6 @@ ibus_engine_simple_init (IBusEngineSimple *simple)
     priv->tentative_match_len = 0;
     priv->updated_preedit =
             (IBusText *)g_object_ref_sink (updated_preedit_empty);
-    data = g_resources_lookup_data ("/org/freedesktop/ibus/compose/sequences",
-                                    G_RESOURCE_LOOKUP_FLAGS_NONE,
-                                    &error);
-    if (error) {
-        g_warning ("Not found compose resource %s", error->message);
-        g_clear_error (&error);
-        return;
-    }
-    contents = g_bytes_get_data (data, &length);
-    en_compose_table = ibus_compose_table_deserialize (contents, length, FALSE);
     if (!en_compose_table) {
         g_warning ("Failed to load EN compose table");
     } else {
@@ -815,6 +825,7 @@ ibus_engine_simple_check_all_compose_table (IBusEngineSimple *simple,
     GString *output = g_string_new ("");
     gboolean success = FALSE;
     gboolean is_32bit = FALSE;
+    gboolean can_load_en_us = FALSE;
     gunichar output_char = '\0';
 
     /* GtkIMContextSimple output the first compose char in case of
@@ -826,27 +837,33 @@ ibus_engine_simple_check_all_compose_table (IBusEngineSimple *simple,
     G_LOCK (global_tables);
     tmp_list = global_tables;
     while (tmp_list) {
+        IBusComposeTableEx *compose_table = tmp_list->data;
+        if (compose_table->can_load_en_us)
+            can_load_en_us = TRUE;
+        /* en_compose_table is always appended to the last of global_tables. */
+        if ((compose_table == en_compose_table) && !can_load_en_us) {
+            tmp_list = tmp_list->next;
+            continue;
+        }
         is_32bit = FALSE;
-        if (ibus_compose_table_check (
-            (IBusComposeTableEx *)tmp_list->data,
-            priv->compose_buffer,
-            n_compose,
-            &compose_finish,
-            &compose_match,
-            output,
-            is_32bit)) {
+        if (ibus_compose_table_check (compose_table,
+                                      priv->compose_buffer,
+                                      n_compose,
+                                      &compose_finish,
+                                      &compose_match,
+                                      output,
+                                      is_32bit)) {
             success = TRUE;
             break;
         }
         is_32bit = TRUE;
-        if (ibus_compose_table_check (
-            (IBusComposeTableEx *)tmp_list->data,
-            priv->compose_buffer,
-            n_compose,
-            &compose_finish,
-            &compose_match,
-            output,
-            is_32bit)) {
+        if (ibus_compose_table_check (compose_table,
+                                      priv->compose_buffer,
+                                      n_compose,
+                                      &compose_finish,
+                                      &compose_match,
+                                      output,
+                                      is_32bit)) {
             success = TRUE;
             break;
         }
@@ -1536,7 +1553,7 @@ gboolean
 ibus_engine_simple_add_compose_file (IBusEngineSimple *simple,
                                      const gchar      *compose_file)
 {
-    g_return_val_if_fail (IBUS_IS_ENGINE_SIMPLE (simple), TRUE);
+    g_return_val_if_fail (IBUS_IS_ENGINE_SIMPLE (simple), FALSE);
 
     global_tables = ibus_compose_table_list_add_file (global_tables,
                                                       compose_file);

--- a/src/ibusenginesimpleprivate.h
+++ b/src/ibusenginesimpleprivate.h
@@ -1,7 +1,7 @@
 /* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
- * Copyright (C) 2016-2024 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2016-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
  * Copyright (C) 2016 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -55,7 +55,7 @@ IBusComposeTableEx *
          ibus_compose_table_deserialize
                                     (const char                 *contents,
                                      gsize                       length,
-                                     gboolean                   reverse_endian);
+                                     guint16                    *saved_version);
 gboolean ibus_compose_table_check   (const IBusComposeTableEx   *table,
                                      guint                      *compose_buffer,
                                      int                         n_compose,

--- a/src/tests/ibus-compose.c
+++ b/src/tests/ibus-compose.c
@@ -241,9 +241,14 @@ create_engine_cb (IBusFactory *factory,
     else
         compose_path = get_compose_path ();
     if (compose_path != NULL) {
+        guint16 saved_version = 0;
         ibus_engine_simple_add_compose_file (IBUS_ENGINE_SIMPLE (m_engine),
                                              compose_path);
-        m_compose_table = ibus_compose_table_load_cache (compose_path);
+        m_compose_table = ibus_compose_table_load_cache (compose_path,
+                                                         &saved_version);
+        if (m_compose_table)
+            g_assert (saved_version);
+
     }
     g_free (compose_path);
     return m_engine;


### PR DESCRIPTION
IBus follows the GTK4 changes below.
- Keep compose preedit with wrong sequence
- Do not load en-US compose table by default