### PR TITLE
Support overlay keys

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -183,29 +183,30 @@ static char _use_sync_mode = 1;
 
 static guint wayland_im_signals[LAST_SIGNAL] = { 0 };
 
+/* common with IBUS_COMPOSE_IGNORE_KEYLIST[]
+* and invalid_accelerator_vals[].
+*/
 static const guint repeat_ignore[] = {
-  0,
-  IBUS_KEY_Overlay1_Enable,
-  IBUS_KEY_Overlay2_Enable,
-  IBUS_KEY_Shift_L,
-  IBUS_KEY_Shift_R,
-  IBUS_KEY_Control_L,
-  IBUS_KEY_Control_R,
-  IBUS_KEY_Caps_Lock,
-  IBUS_KEY_Shift_Lock,
-  IBUS_KEY_Meta_L,
-  IBUS_KEY_Meta_R,
-  IBUS_KEY_Alt_L,
-  IBUS_KEY_Alt_R,
-  IBUS_KEY_Super_L,
-  IBUS_KEY_Super_R,
-  IBUS_KEY_Hyper_L,
-  IBUS_KEY_Hyper_R,
-  IBUS_KEY_Mode_switch,
-  IBUS_KEY_ISO_Level3_Shift,
-  IBUS_KEY_ISO_Level3_Latch,
-  IBUS_KEY_ISO_Level5_Shift,
-  IBUS_KEY_ISO_Level5_Latch
+    0,
+    IBUS_KEY_Shift_L, IBUS_KEY_Shift_R,
+    IBUS_KEY_Control_L, IBUS_KEY_Control_R,
+    IBUS_KEY_Caps_Lock, IBUS_KEY_Shift_Lock, IBUS_KEY_ISO_Lock,
+    IBUS_KEY_Meta_L, IBUS_KEY_Meta_R,
+    IBUS_KEY_Alt_L, IBUS_KEY_Alt_R,
+    IBUS_KEY_Super_L, IBUS_KEY_Super_R,
+    IBUS_KEY_Hyper_L, IBUS_KEY_Hyper_R,
+    IBUS_KEY_ISO_Level2_Latch,
+    IBUS_KEY_ISO_Level3_Latch, IBUS_KEY_ISO_Level3_Lock,
+    IBUS_KEY_ISO_Level3_Shift,
+    IBUS_KEY_ISO_Level5_Latch, IBUS_KEY_ISO_Level5_Lock,
+    IBUS_KEY_ISO_Level5_Shift,
+    IBUS_KEY_ISO_Group_Latch, IBUS_KEY_ISO_Group_Lock,
+    IBUS_KEY_ISO_Group_Shift,
+    IBUS_KEY_ISO_Next_Group, IBUS_KEY_ISO_Next_Group_Lock,
+    IBUS_KEY_ISO_Prev_Group, IBUS_KEY_ISO_Prev_Group_Lock,
+    IBUS_KEY_ISO_First_Group, IBUS_KEY_ISO_First_Group_Lock,
+    IBUS_KEY_ISO_Last_Group, IBUS_KEY_ISO_Last_Group_Lock,
+    IBUS_KEY_Overlay1_Enable, IBUS_KEY_Overlay2_Enable
 };
 
 static void         input_method_deactivate

--- a/src/ibusaccelgroup.c
+++ b/src/ibusaccelgroup.c
@@ -63,8 +63,9 @@ ibus_accelerator_valid (guint           keyval,
                         IBusModifierType modifiers)
 {
     static const guint invalid_accelerator_vals[] = {
-        /* common keys between invalid_accelerator_vals[] and
-         * IBUS_COMPOSE_IGNORE_KEYLIST[].
+        /* common keys between invalid_accelerator_vals[],
+         * IBUS_COMPOSE_IGNORE_KEYLIST[], and
+         * repeat_ignore[].
          */
         IBUS_KEY_Shift_L, IBUS_KEY_Shift_R,
         IBUS_KEY_Control_L, IBUS_KEY_Control_R,
@@ -73,7 +74,6 @@ ibus_accelerator_valid (guint           keyval,
         IBUS_KEY_Alt_L, IBUS_KEY_Alt_R,
         IBUS_KEY_Super_L, IBUS_KEY_Super_R,
         IBUS_KEY_Hyper_L, IBUS_KEY_Hyper_R,
-        IBUS_KEY_Mode_switch,
         IBUS_KEY_ISO_Level2_Latch,
         IBUS_KEY_ISO_Level3_Latch, IBUS_KEY_ISO_Level3_Lock,
         IBUS_KEY_ISO_Level3_Shift,
@@ -85,6 +85,7 @@ ibus_accelerator_valid (guint           keyval,
         IBUS_KEY_ISO_Prev_Group, IBUS_KEY_ISO_Prev_Group_Lock,
         IBUS_KEY_ISO_First_Group, IBUS_KEY_ISO_First_Group_Lock,
         IBUS_KEY_ISO_Last_Group, IBUS_KEY_ISO_Last_Group_Lock,
+        IBUS_KEY_Overlay1_Enable, IBUS_KEY_Overlay2_Enable,
         /* invalid_accelerator_vals[] specific keys */
         IBUS_KEY_Num_Lock, IBUS_KEY_Multi_key,
         IBUS_KEY_Scroll_Lock, IBUS_KEY_Sys_Req,

--- a/src/ibusenginesimple.h
+++ b/src/ibusenginesimple.h
@@ -95,6 +95,9 @@ struct _IBusEngineSimpleClass {
     gpointer pdummy[8];
 };
 
+/* common with invalid_accelerator_vals[],
+* and repeat_ignore[].
+*/
 static const guint16 IBUS_COMPOSE_IGNORE_KEYLIST[] = {
     IBUS_KEY_Shift_L, IBUS_KEY_Shift_R,
     IBUS_KEY_Control_L, IBUS_KEY_Control_R,
@@ -103,7 +106,6 @@ static const guint16 IBUS_COMPOSE_IGNORE_KEYLIST[] = {
     IBUS_KEY_Alt_L, IBUS_KEY_Alt_R,
     IBUS_KEY_Super_L, IBUS_KEY_Super_R,
     IBUS_KEY_Hyper_L, IBUS_KEY_Hyper_R,
-    IBUS_KEY_Mode_switch,
     IBUS_KEY_ISO_Level2_Latch,
     IBUS_KEY_ISO_Level3_Latch, IBUS_KEY_ISO_Level3_Lock,
     IBUS_KEY_ISO_Level3_Shift,
@@ -114,8 +116,8 @@ static const guint16 IBUS_COMPOSE_IGNORE_KEYLIST[] = {
     IBUS_KEY_ISO_Next_Group, IBUS_KEY_ISO_Next_Group_Lock,
     IBUS_KEY_ISO_Prev_Group, IBUS_KEY_ISO_Prev_Group_Lock,
     IBUS_KEY_ISO_First_Group, IBUS_KEY_ISO_First_Group_Lock,
-    IBUS_KEY_ISO_Last_Group,
-    IBUS_KEY_ISO_Last_Group_Lock
+    IBUS_KEY_ISO_Last_Group, IBUS_KEY_ISO_Last_Group_Lock,
+    IBUS_KEY_Overlay1_Enable, IBUS_KEY_Overlay2_Enable
 };
 
 GType   ibus_engine_simple_get_type       (void);


### PR DESCRIPTION
Follow-up to 6b80252afabc8d2a02ef2a53156015d088828a5f to ensure the `Overlay1_Enable` and `Overlay2_Enable` keys are also properly ignored.

Also updates the `repeat_ignore` list in `ibuswaylandim.c`, for consistency.