### PR TITLE
ui/gtk3: Fix time lag of CandidatePanel in X11

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -1332,6 +1332,17 @@ _process_key_event_repeat_delay_cb (gpointer user_data)
     /* The key release event was sent to non-Wayland apps likes xterm. */
     if (!priv->ibuscontext) {
         event->count_cb_id = 0;
+        /* Stop the infinite Return keys in non-Wayland apps likes xterm in
+         * the Sway desktop session.
+         * But priv->context in NULL in the Wayland input-method V1 here.
+         */
+        if (priv->version != INPUT_METHOD_V1) {
+            ibus_wayland_im_key(event->wlim,
+                                event->serial,
+                                event->time + priv->repeat_delay,
+                                event->key,
+                                WL_KEYBOARD_KEY_STATE_RELEASED);
+        }
         return G_SOURCE_REMOVE;
     }
     /* The focus is changed. */

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -173,7 +173,8 @@ class Panel : IBus.PanelService {
     }
 
     private CandidatePanel candidate_panel_new(bool no_wayland_panel) {
-        CandidatePanel candidate_panel = new CandidatePanel(no_wayland_panel);
+        CandidatePanel candidate_panel = new CandidatePanel(m_is_wayland,
+                                                            no_wayland_panel);
         candidate_panel.page_up.connect((w) => this.page_up());
         candidate_panel.page_down.connect((w) => this.page_down());
         candidate_panel.cursor_up.connect((w) => this.cursor_up());
@@ -190,7 +191,7 @@ class Panel : IBus.PanelService {
     }
 
     private Switcher switcher_new(bool no_wayland_panel) {
-        Switcher switcher = new Switcher(no_wayland_panel);
+        Switcher switcher = new Switcher(m_is_wayland, no_wayland_panel);
 #if USE_GDK_WAYLAND
         switcher.realize_surface.connect(
                 (w, s) => this.realize_surface(s));

--- a/ui/gtk3/xkblayout.vala
+++ b/ui/gtk3/xkblayout.vala
@@ -48,6 +48,11 @@ class XKBLayout
     public void get_layout(out string layout,
                            out string variant,
                            out string option) {
+        layout = "";
+        variant = "";
+        var o = Environment.get_variable("XKB_DEFAULT_OPTIONS");
+        option = o != null ? o : "";
+
         search_get_layout_program();
         if (m_get_layout_args[0] == null) {
             warning("Not found localectl or setxkbmap command in PATH");
@@ -59,11 +64,6 @@ class XKBLayout
         string standard_output = null;
         string standard_error = null;
         int exit_status = 0;
-
-        layout = "";
-        variant = "";
-        var o = Environment.get_variable("XKB_DEFAULT_OPTIONS");
-        option = o != null ? o : "";
 
         try {
             GLib.Process.spawn_sync(null,
@@ -84,14 +84,14 @@ class XKBLayout
 
         if (exec_command[0] == "localectl") {
             parse_localectl_status_str(standard_output,
-                                       out layout,
-                                       out variant,
-                                       out option);
+                                       ref layout,
+                                       ref variant,
+                                       ref option);
         } else if (exec_command[0] == XKB_COMMAND) {
             parse_xkbmap_query_str(standard_output,
-                                   out layout,
-                                   out variant,
-                                   out option);
+                                   ref layout,
+                                   ref variant,
+                                   ref option);
         }
     }
 
@@ -113,9 +113,9 @@ class XKBLayout
 
 
     private void parse_localectl_status_str(string standard_output,
-                                            out string layout,
-                                            out string variant,
-                                            out string option) {
+                                            ref string layout,
+                                            ref string variant,
+                                            ref string option) {
         foreach (string line in standard_output.split("\n")) {
             const string[] elements = { "X11 Layout:", "X11 Variant:" };
             foreach (unowned string element in elements) {
@@ -136,9 +136,9 @@ class XKBLayout
 
 
     private void parse_xkbmap_query_str(string standard_output,
-                                        out string layout,
-                                        out string variant,
-                                        out string option) {
+                                        ref string layout,
+                                        ref string variant,
+                                        ref string option) {
         foreach (string line in standard_output.split("\n")) {
             const string[] elements = { "layout:", "variant:", "options:" };
             foreach (unowned string element in elements) {


### PR DESCRIPTION
The timed `set_lookup_table()` is a workaround with the Wayland
input-method protocol under the construction to stop the many D-Bus
methods but it should not affect Xorg UI at least.

Now `m_is_wayland flag` is inherited to the CandidatePanel and Switcher
and add `m_first_set_lookup_table` flag newly to enhance the lag
with the Wayland input-method protocol.

Fixes: https://github.com/ibus/ibus/commit/d5e6e71
BUG=https://github.com/ibus/ibus/issues/2740

client/wayland: Fix infinite Return key in xterm

Currently the repeating key feature of IBus is disabled when the focus
is changed but the feature of the Wayland compositor still happens in
the Sway desktop session when invoke xterm by manual in foot.
I think Sway should stop the repeating key feature when the focus is
changed from the Wayland application to the non-Wayland application.

I add a workaround to call `zwp_virtual_keyboard_v1_key()` with
the `WL_KEYBOARD_KEY_STATE_RELEASED` flag to stop the feature of
the Sway compositor after the IBus repeating key timeout.
