### PR TITLE
src/ibusenginesimple: Improve BEPO compose sequence visuals

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -601,6 +601,20 @@ AC_ARG_WITH(gtk4-im-module-dir,
 )
 AC_SUBST(GTK4_IM_MODULEDIR)
 
+AC_MSG_CHECKING([for $PYTHON GI GnomeDesktop module])
+if AC_RUN_LOG([$PYTHON -c "def _configure_test():
+    from gi import require_version as gi_require_version
+    gi_require_version('GnomeDesktop', '4.0')
+    from gi.repository import GnomeDesktop
+_configure_test()"]); then
+    enable_pygnome_desktop="yes"
+else
+    enable_pygnome_desktop="no"
+fi
+AC_MSG_RESULT([$enable_pygnome_desktop])
+AM_CONDITIONAL([ENABLE_PYGNOME_DESKTOP],
+               [test x"$enable_pygnome_desktop" = x"yes"])
+
 if test x"$enable_python" = x"yes"; then
     # Check for dbus-python.
     AC_ARG_ENABLE(dbus-python-check,
@@ -941,6 +955,7 @@ Build options:
   PYTHON                        $PYTHON
   PYTHON2                       $PYTHON2
   Python overrides dir          $pyoverridesdir
+  Python GI GnomeDesktop module $enable_pygnome_desktop
   Enable python2                $enable_python2
   Gtk2 immodule dir             $GTK2_IM_MODULEDIR
   Gtk3 immodule dir             $GTK3_IM_MODULEDIR

--- a/engine/Makefile.am
+++ b/engine/Makefile.am
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2010-2016, Google Inc. All rights reserved.
 # Copyright (c) 2007-2016 Peng Huang <shawn.p.huang@gmail.com>
-# Copyright (c) 2013-2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2013-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -24,76 +24,83 @@
 libibus = $(top_builddir)/src/libibus-@IBUS_API_VERSION@.la
 
 AM_CPPFLAGS = \
-	-I$(top_srcdir)/src \
-	-I$(top_builddir)/src \
-	$(NULL)
+    -I$(top_srcdir)/src \
+    -I$(top_builddir)/src \
+    $(NULL)
 
 AM_CFLAGS = \
-	@GLIB2_CFLAGS@ \
-	@GIO2_CFLAGS@ \
-	@GTHREAD2_CFLAGS@ \
-	-DG_LOG_DOMAIN=\"IBUS\" \
-	-DPKGDATADIR=\"$(pkgdatadir)\" \
-	-DLIBEXECDIR=\"$(libexecdir)\" \
-	-DBINDIR=\"@bindir@\" \
+    @GLIB2_CFLAGS@ \
+    @GIO2_CFLAGS@ \
+    @GTHREAD2_CFLAGS@ \
+    -DG_LOG_DOMAIN=\"IBUS\" \
+    -DPKGDATADIR=\"$(pkgdatadir)\" \
+    -DLIBEXECDIR=\"$(libexecdir)\" \
+    -DBINDIR=\"@bindir@\" \
     -DIBUS_DISABLE_DEPRECATED \
-	-Wno-unused-variable \
-	-Wno-unused-but-set-variable \
-	-Wno-unused-function \
-	$(NULL)
+    -Wno-unused-variable \
+    -Wno-unused-but-set-variable \
+    -Wno-unused-function \
+    $(NULL)
 
 AM_LDADD = \
-	@GOBJECT2_LIBS@ \
-	@GLIB2_LIBS@ \
-	@GIO2_LIBS@ \
-	@GTHREAD2_LIBS@ \
-	$(libibus) \
-	$(NULL)
+    @GOBJECT2_LIBS@ \
+    @GLIB2_LIBS@ \
+    @GIO2_LIBS@ \
+    @GTHREAD2_LIBS@ \
+    $(libibus) \
+    $(NULL)
 
 AM_VALAFLAGS = \
-	--vapidir=$(top_builddir)/bindings/vala \
-	--pkg=ibus-1.0 \
+    --vapidir=$(top_builddir)/bindings/vala \
+    --pkg=ibus-1.0 \
     --pkg-config="\"$(PKG_CONFIG) --with-path=$(PKG_CONFIG_PATH)\"" \
-	--target-glib="$(VALA_TARGET_GLIB_VERSION)" \
-	$(NULL)
+    --target-glib="$(VALA_TARGET_GLIB_VERSION)" \
+    $(NULL)
+
+TESTS =
+
+if ENABLE_PYGNOME_DESKTOP
+TESTS += test-gnome.py
+endif
 
 libexec_PROGRAMS = \
-	ibus-engine-simple \
-	$(NULL)
+    ibus-engine-simple \
+    $(NULL)
 
 ibus_engine_simple_SOURCES = \
-	main.vala \
-	$(NULL)
+    main.vala \
+    $(NULL)
 ibus_engine_simple_CFLAGS = \
-	$(AM_CFLAGS) \
-	$(NULL)
+    $(AM_CFLAGS) \
+    $(NULL)
 ibus_engine_simple_LDADD = \
-	$(AM_LDADD) \
-	$(NULL)
+    $(AM_LDADD) \
+    $(NULL)
 ibus_engine_simple_DEPENDENCIES = \
-	$(libibus) \
-	$(NULL)
+    $(libibus) \
+    $(NULL)
 
 component_DATA = \
-	simple.xml \
-	$(NULL)
+    simple.xml \
+    $(NULL)
 
 componentdir = $(pkgdatadir)/component
 
 MAINTAINERCLEANFILES = \
-	simple.xml.in \
-	$(NULL)
+    simple.xml.in \
+    $(NULL)
 
 CLEANFILES = \
-	simple.xml \
-	$(NULL)
+    simple.xml \
+    $(NULL)
 
 EXTRA_DIST = \
-	denylist.txt \
-	gensimple.py \
-	iso639converter.py \
-	simple.xml.in \
-	$(NULL)
+    denylist.txt \
+    gensimple.py \
+    iso639converter.py \
+    simple.xml.in \
+    test-gnome.py \
+    $(NULL)
 
 simple.xml: simple.xml.in
 	$(AM_V_GEN) sed \

--- a/engine/test-gnome.py
+++ b/engine/test-gnome.py
@@ -1,0 +1,132 @@
+#!/usr/bin/python
+# vim:set fileencoding=utf-8 et sts=4 sw=4:
+#
+# ibus - Intelligent Input Bus for Linux / Unix OS
+#
+# Copyright © 2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+# Check gnome-shell/js/misc/keyboardManager.js
+
+from gi import require_version as gi_require_version
+gi_require_version('GnomeDesktop', '4.0')
+
+from gi.repository import GnomeDesktop
+
+import os, re, sys
+
+
+class TestGnomeDesktop:
+    __srcdir = '.'
+    __option_debug = False
+    __simple_filename = 'simple.xml.in'
+    __denylist_filename = 'denylist.txt'
+    __xkb_info = None
+    __simple_contents = None
+    __denylist_lines = None
+
+    @classmethod
+    def parse_args(cls):
+        cls.__srcdir = os.path.dirname(sys.argv[0])
+        if cls.__srcdir == '':
+            cls.__srcdir = '.'
+        if len(sys.argv) > 1:
+            arg1 = sys.argv[1]
+            if arg1 == '--debug':
+                cls.__option_debug = True
+
+    def __init__(self):
+        self.__simple_filename = '%s/%s' % (self.__srcdir,
+                                            self.__simple_filename)
+        self.__denylist_filename = '%s/%s' % (self.__srcdir,
+                                              self.__denylist_filename)
+        self.__xkb_info = GnomeDesktop.XkbInfo()
+
+    def read_simple(self):
+        simple_file = open(self.__simple_filename)
+        self.__simple_contents = simple_file.read()
+        simple_file.close()
+
+    def read_denylist(self):
+        denylist_file = open(self.__denylist_filename)
+        self.__denylist_lines = denylist_file.readlines()
+        denylist_file.close()
+        l = []
+        for line in self.__denylist_lines:
+            line = line.rstrip()
+            if len(line) == 0:
+                continue
+            if not line.startswith('#'):
+                l.append(line)
+        self.__denylist_lines = l
+
+    def __check_known_issue_engine_name(self, desc):
+        reason = None
+        if desc == 'xkb:in:eng:eng':
+            wrong_desc = 'xkb:in:eng:en'
+            simple_res = re.search(wrong_desc, self.__simple_contents)
+            if simple_res != None:
+                reason = '# Info: xkeyboard-config 2.42 has incorrect %s ' \
+                         "but it's fixed in 2.44" % wrong_desc
+        return reason
+
+    def test_simple_with_gnome(self):
+        errnum = 0
+        for layout_variant in self.__xkb_info.get_all_layouts():
+            languages = self.__xkb_info.get_languages_for_layout(layout_variant)
+            layouts = layout_variant.split('+')
+            if len(languages) == 0:
+                if self.__option_debug:
+                    print('# Info: No language: %s' % layout_variant)
+                continue
+            if len(layouts) >= 2:
+                desc = 'xkb:%s:%s:%s' % (layouts[0], layouts[1], languages[0])
+            else:
+                desc = 'xkb:%s::%s' % (layouts[0], languages[0])
+            if self.__option_debug:
+                print('# Debug: Test', layout_variant, languages, desc)
+            simple_res = re.search(desc, self.__simple_contents)
+            if simple_res == None:
+                denylist_res = None
+                for line in self.__denylist_lines:
+                    denylist_res = re.match(line, desc)
+                    if denylist_res != None:
+                        break
+                if denylist_res == None:
+                    reason = self.__check_known_issue_engine_name(desc)
+                    if reason != None:
+                        if self.__option_debug:
+                            print(reason)
+                    else:
+                        errnum = errnum + 1
+                        print('# Error: not found: %s' % desc, file=sys.stderr)
+                elif self.__option_debug:
+                    print('# Info: %s in denylist' % desc)
+        return errnum
+
+
+def main():
+    TestGnomeDesktop.parse_args()
+    obj = TestGnomeDesktop()
+    obj.read_simple()
+    obj.read_denylist()
+    errnum = obj.test_simple_with_gnome()
+    if errnum == 0:
+        print('Succeeded.')
+    else:
+        print('Failed. %s errors found.' % errnum, file=sys.stderr)
+        sys.exit(1)
+
+main()

--- a/po/ibus10.pot
+++ b/po/ibus10.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: ibus 1.5.32\n"
 "Report-Msgid-Bugs-To: https://github.com/ibus/ibus/issues\n"
-"POT-Creation-Date: 2025-06-01 18:56+0900\n"
+"POT-Creation-Date: 2025-06-01 21:56+0900\n"
 "PO-Revision-Date: 2025-05-19 12:12+0900\n"
 "Last-Translator: Takao Fujiwara <takao.fujiwara1@gmail.com>\n"
 "Language-Team: Source\n"
@@ -819,6 +819,32 @@ msgstr ""
 msgid "Advanced"
 msgstr ""
 
+#: src/ibuscomposetable.c:1780
+#, c-format
+msgid ""
+"Since IBus 1.5.33, Compose files replace the builtin\n"
+"compose sequences. To keep them and add your own\n"
+"sequences on top, the line:\n"
+"\n"
+"  include \"%%L\"\n"
+"\n"
+"has been added to the Compose file:\n"
+"%s.\n"
+msgstr ""
+
+#: src/ibuscomposetable.c:1801
+#, c-format
+msgid ""
+"Since IBus 1.5.33, Compose files replace the builtin\n"
+"compose sequences. To keep them and add your own\n"
+"sequences on top, you need to add the line:\n"
+"\n"
+"  include \"%%L\"\n"
+"\n"
+"to the Compose file:\n"
+"%s."
+msgstr ""
+
 #: src/ibusemojigen.h:30
 msgid "Activities"
 msgstr ""
@@ -869,6 +895,10 @@ msgid ""
 "currently active compose sequence and the character was cancelled. Try "
 "inputting the correct character to the compose sequence again, or press "
 "Escape key to terminate whole the compose sequence."
+msgstr ""
+
+#: src/ibusenginesimple.c:276
+msgid "Compose file update"
 msgstr ""
 
 #. TRANSLATORS: You might refer the translations from gucharmap with

--- a/src/gencomposetable.c
+++ b/src/gencomposetable.c
@@ -1,8 +1,8 @@
 /* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
- * Copyright (C) 2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
- * Copyright (C) 2023 Red Hat, Inc.
+ * Copyright (C) 2023-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2023-2025 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -76,6 +76,7 @@ main (int argc, char *argv[])
     char * const *sys_lang = NULL;
     char *path = NULL;
     IBusComposeTableEx *compose_table;
+    guint16 saved_version = 0;
     char *basename = NULL;
 
     path = g_strdup ("./Compose");
@@ -97,13 +98,15 @@ main (int argc, char *argv[])
         g_debug ("Create a cache of %s", path);
     }
     g_setenv ("IBUS_COMPOSE_CACHE_DIR", ".", TRUE);
-    compose_table = ibus_compose_table_load_cache (path);
+    compose_table = ibus_compose_table_load_cache (path, &saved_version);
     if (!compose_table &&
         (compose_table = ibus_compose_table_new_with_file (path, NULL))
            == NULL) {
         g_warning ("Failed to generate the compose table.");
         return 1;
     }
+    if (saved_version > 0)
+        g_warning ("Old cache was updated.");
     g_free (path);
     basename = g_strdup_printf ("%08x.cache", compose_table->id);
     g_debug ("Saving cache id %s", basename);

--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -2058,11 +2058,36 @@ ibus_keysym_to_unicode (guint     keysym,
          * we use U+00B7, MIDDLE DOT.
          */
         return 0x00B7;
-    default:;
+    default:
         if (need_space)
             *need_space = FALSE;
     }
     return 0x0;
 #undef CASE
 #undef CASE_COMBINE
+}
+
+gunichar
+ibus_keysym_to_unicode_with_layout (guint                      keysym,
+                                    gboolean                   combining,
+                                    gboolean                  *need_space,
+                                    const gchar               *layout,
+                                    G_GNUC_UNUSED const gchar *variant) {
+#define CASE_KEYSYM(keysym_val, unicode)                                      \
+        case keysym_val:                                                      \
+            if (need_space)                                                   \
+                *need_space = FALSE;                                          \
+            return unicode
+    /* Refer (BEPO, AFNOR) comments in /usr/share/X11/xkb/symbols/fr file. */
+    if (!g_ascii_strncasecmp (layout, "fr", 2)) {
+        switch (keysym) {
+            CASE_KEYSYM(0x0100FDD4, 0x00DF); /* ß */
+            CASE_KEYSYM(0x0100FDD5, 0x1D49); /* ᵉ */
+            CASE_KEYSYM(0x0100FDD7, 0x221E); /* ∞ */
+            CASE_KEYSYM(0x0100FDD8, 0x2015); /* ― */
+            default:;
+        }
+    }
+#undef CASE_KEYSYM
+    return ibus_keysym_to_unicode (keysym, combining, need_space);
 }

--- a/src/ibuscomposetable.h
+++ b/src/ibuscomposetable.h
@@ -2,7 +2,7 @@
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
  * Copyright (C) 2013-2014 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2013-2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2013-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,8 +23,19 @@
 #ifndef __IBUS_COMPOSETABLE_H_
 #define __IBUS_COMPOSETABLE_H_
 
-#include <glib.h>
+/**
+ * SECTION: ibuscomposetable
+ * @short_description: Compose table handling based on libX11
+ * @title: IBusComposeTable
+ * @stability: Unstable
+ *
+ * Generate #IBusComposeTableEx with the compose file or array.
+ *
+ * see_also: #IBusEngineSimple
+ *
+ */
 
+#include <glib.h>
 
 G_BEGIN_DECLS
 
@@ -53,6 +64,7 @@ struct _IBusComposeTableEx
     gint n_seqs;
     guint32 id;
     char *rawdata;
+    gboolean can_load_en_us;
 };
 
 
@@ -71,8 +83,11 @@ IBusComposeTableEx *
                   ibus_compose_table_new_with_file (const gchar *compose_file,
                                                     GSList
                                                                *compose_tables);
+void               ibus_compose_table_free         (IBusComposeTableEx
+                                                                *compose_table);
 IBusComposeTableEx *
-                  ibus_compose_table_load_cache    (const gchar *compose_file);
+                  ibus_compose_table_load_cache    (const gchar *compose_file,
+                                                    guint16     *saved_version);
 void              ibus_compose_table_save_cache    (IBusComposeTableEx
                                                                 *compose_table);
 GSList *          ibus_compose_table_list_add_array
@@ -84,7 +99,8 @@ GSList *          ibus_compose_table_list_add_array
                                                     gint         n_seqs);
 GSList *          ibus_compose_table_list_add_file (GSList
                                                                 *compose_tables,
-                                                    const gchar *compose_file);
+                                                    const gchar *compose_file,
+                                                    GError     **error);
 GSList *          ibus_compose_table_list_add_table (GSList
                                                                 *compose_tables,
                                                      IBusComposeTableEx

--- a/src/ibusengine.h
+++ b/src/ibusengine.h
@@ -71,6 +71,8 @@ G_BEGIN_DECLS
  * @IBUS_ENGINE_MSG_CODE_GENERAL: Generic message for Engine
  * @IBUS_ENGINE_MSG_CODE_INVALID_COMPOSE_SEQUENCE: User's typing failure
  *         against the definition of the compose files.
+ * @IBUS_ENGINE_MSG_CODE_UPDATE_COMPOSE_TABLE: Notification about new
+ * behaviors or attentions when the compose table version is changed.
  *
  * Message codes in the `IBusMessageDomain` domain for Engine
  * See also #IBusMessage, ibus_engine_send_message()
@@ -81,7 +83,8 @@ G_BEGIN_DECLS
 typedef enum
 {
   IBUS_ENGINE_MSG_CODE_GENERAL,
-  IBUS_ENGINE_MSG_CODE_INVALID_COMPOSE_SEQUENCE
+  IBUS_ENGINE_MSG_CODE_INVALID_COMPOSE_SEQUENCE,
+  IBUS_ENGINE_MSG_CODE_UPDATE_COMPOSE_TABLE
 } IBusEngineMsgCode;
 
 typedef struct _IBusEngine IBusEngine;

--- a/src/ibusenginesimpleprivate.h
+++ b/src/ibusenginesimpleprivate.h
@@ -65,6 +65,18 @@ gboolean ibus_compose_table_check   (const IBusComposeTableEx   *table,
 gunichar ibus_keysym_to_unicode     (guint                       keysym,
                                      gboolean                    combining,
                                      gboolean                   *need_space);
+/**
+ * ibus_keysym_to_unicode_with_layout:
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+gunichar ibus_keysym_to_unicode_with_layout
+                                    (guint                       keysym,
+                                     gboolean                    combining,
+                                     gboolean                   *need_space,
+                                     const gchar                *layout,
+                                     G_GNUC_UNUSED const gchar  *variant);
 
 G_END_DECLS
 

--- a/src/ibusenginesimpleprivate.h
+++ b/src/ibusenginesimpleprivate.h
@@ -26,6 +26,15 @@
 
 G_BEGIN_DECLS
 
+/**
+ * IBUS_COMPOSE_ERROR:
+ *
+ * The `GQuark` used for `IBusComposeTableEx` errors.
+ *
+ * Since: 1.5.33
+ */
+#define IBUS_COMPOSE_ERROR (ibus_compose_error_quark ())
+
 /* Checks if a keysym is a dead key. Dead key keysym values are defined in
  * ibuskeysyms.h and the first is GDK_KEY_dead_grave.
  */
@@ -42,6 +51,13 @@ struct _IBusComposeTablePrivate
 };
 
 
+/**
+ * ibus_compose_error_quark:
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+GQuark   ibus_compose_error_quark   (void);
 guint    ibus_compose_key_flag      (guint                       key);
 gboolean ibus_check_algorithmically (const guint                *compose_buffer,
                                      int                         n_compose,
@@ -54,7 +70,8 @@ GVariant *
 IBusComposeTableEx *
          ibus_compose_table_deserialize
                                     (const char                 *contents,
-                                     gsize                       length);
+                                     gsize                       length,
+                                     guint16                    *saved_version);
 gboolean ibus_compose_table_check   (const IBusComposeTableEx   *table,
                                      guint                      *compose_buffer,
                                      int                         n_compose,

--- a/src/tests/Makefile.am
+++ b/src/tests/Makefile.am
@@ -3,7 +3,7 @@
 # ibus - The Input Bus
 #
 # Copyright (c) 2007-2015 Peng Huang <shawn.p.huang@gmail.com>
-# Copyright (c) 2015-2024 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2015-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
 # Copyright (c) 2007-2018 Red Hat, Inc.
 #
 # This library is free software; you can redistribute it and/or
@@ -77,6 +77,10 @@ TESTS_C += ibus-compose
 if ENABLE_XTEST
 TESTS_C += ibus-keypress
 endif
+endif
+
+if ENABLE_GTK4
+TESTS_C += ibus-keyval
 endif
 
 TESTS_ENVIRONMENT = \
@@ -223,6 +227,10 @@ ibus_keypress_CFLAGS = @GTK3_CFLAGS@ @XTEST_CFLAGS@
 ibus_keypress_LDADD = $(prog_ldadd) @GTK3_LIBS@ @XTEST_LIBS@
 endif
 endif
+
+ibus_keyval_SOURCES = ibus-keyval.c
+ibus_keyval_CFLAGS = @GTK4_CFLAGS@
+ibus_keyval_LDADD = $(prog_ldadd) @GTK4_LIBS@
 
 ibus_registry_SOURCES = ibus-registry.c
 ibus_registry_LDADD = $(prog_ldadd)

--- a/src/tests/ibus-compose.c
+++ b/src/tests/ibus-compose.c
@@ -241,9 +241,13 @@ create_engine_cb (IBusFactory *factory,
     else
         compose_path = get_compose_path ();
     if (compose_path != NULL) {
+        guint16 saved_version = 0;
         ibus_engine_simple_add_compose_file (IBUS_ENGINE_SIMPLE (m_engine),
                                              compose_path);
-        m_compose_table = ibus_compose_table_load_cache (compose_path);
+        m_compose_table = ibus_compose_table_load_cache (compose_path,
+                                                         &saved_version);
+        if (m_compose_table)
+            g_assert (saved_version);
     }
     g_free (compose_path);
     return m_engine;

--- a/src/tests/ibus-keyval.c
+++ b/src/tests/ibus-keyval.c
@@ -1,0 +1,74 @@
+/* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
+
+#include <config.h>
+
+#include <gtk/gtk.h>
+#include <ibus.h>
+
+#ifdef ENABLE_NLS
+#include <locale.h>
+#endif
+
+#ifndef MAX
+#define MAX(a, b) (a) >= (b) ? (a) : (b)
+#endif
+
+#define MAX_KEYVAL 0x00FFFFFF
+#define MAX_UNICODE 0x0010FFFF
+
+
+static gboolean
+test_keyval (void)
+{
+    guint si, bi;
+    gunichar ibus_uch, gdk_uch;
+
+    for (si = 0; si < MAX_KEYVAL; ++si) {
+        ibus_uch  = ibus_keyval_to_unicode (si);
+        gdk_uch = gdk_keyval_to_unicode (si);
+        g_assert_cmpuint (ibus_uch, ==, gdk_uch);
+
+        bi = si | 0x01000000;
+        ibus_uch  = ibus_keyval_to_unicode (bi);
+        gdk_uch = gdk_keyval_to_unicode (bi);
+        g_assert_cmpuint (ibus_uch, ==, gdk_uch);
+
+        if (!(si % 0x100000))
+            g_message ("0x%08X/0x%08X is done", si, MAX_KEYVAL);
+    }
+    return TRUE;
+}
+
+
+static gboolean
+test_unicode (void)
+{
+    gunichar i;
+    guint ibus_key, gdk_key;
+    for (i = 0; i < MAX_UNICODE; ++i) {
+        ibus_key = ibus_unicode_to_keyval (i);
+        gdk_key = gdk_unicode_to_keyval (i);
+        g_assert_cmpuint (ibus_key, ==, gdk_key);
+        if (!(i % 0x100000))
+            g_message ("0x%08X/0x%08X is done", i, MAX_UNICODE);
+    }
+    return TRUE;
+}
+
+
+int
+main (int argc, char *argv[])
+{
+#if !GTK_CHECK_VERSION (4, 0, 0)
+    g_message ("The latest GTK 4 is needed for this test case.");
+    return 77;
+#else
+#ifdef ENABLE_NLS
+    setlocale (LC_ALL, "");
+#endif
+    test_keyval ();
+    g_message ("----------");
+    test_unicode ();
+    return EXIT_SUCCESS;
+#endif
+}


### PR DESCRIPTION
The Fr(Bepo) keymap utilizes pseudo-deadkeys within U+FDD0 to U+FDD9 range, which lack readable characters. Now IBus shows the middle dot char(U+00B7) to represent these keys in the compose sequences.

BUG=https://github.com/ibus/ibus/issues/2748
BUG=https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8368