### PR TITLE
ui/gtk3: Fix PageUp/PageDown buttons with hidding candidate popup

### DIFF
--- a/ui/gtk3/candidatepanel.vala
+++ b/ui/gtk3/candidatepanel.vala
@@ -214,7 +214,6 @@ public class CandidatePanel : Gtk.Box{
         m_set_preedit_text_id =
                 Timeout.add(100,
                             () => {
-                                //warning("test set_preedit_text_real");
                                 m_set_preedit_text_id = 0;
                                 set_preedit_text_real(text, cursor);
                                 return Source.REMOVE;
@@ -480,7 +479,11 @@ public class CandidatePanel : Gtk.Box{
     }
 
     public new void show() {
-        m_toplevel.show_all();
+        // m_toplevel.show_all() changes m_candidate_area.get_visible()
+        // in update_real() so show() is just used. Using no_show_all
+        // property for m_candidate_area would introduce the more
+        // complicated logic.
+        m_toplevel.show();
     }
 
     public new void hide() {

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -218,7 +218,7 @@ class Panel : IBus.PanelService {
 
 #if USE_GDK_WAYLAND
     private CandidatePanel get_active_candidate_panel() {
-        if (m_wayland_object_path == null) {
+        if (m_is_wayland && m_wayland_object_path == null) {
             if (m_candidate_panel_x11 == null) {
                 m_candidate_panel_x11 = candidate_panel_new(true);
                 set_use_glyph_from_engine_lang();
@@ -233,7 +233,7 @@ class Panel : IBus.PanelService {
     }
 
     private Switcher get_active_switcher() {
-        if (m_wayland_object_path == null) {
+        if (m_is_wayland && m_wayland_object_path == null) {
             if (m_switcher_x11 == null)
                 m_switcher_x11 = switcher_new(true);
             return m_switcher_x11;


### PR DESCRIPTION
Gtk.Widget.show_all() changes the visibilities of the child widgets and it's not good in case that the parent visibility depends on the visibilities of child widgets. Also using no_show_all property could introduce the more complicated logic to the candidate popup.

BUG=https://github.com/ibus/ibus/issues/2757
Fixes: https://github.com/ibus/ibus/commit/6ac6188 Fixes: https://github.com/ibus/ibus/commit/d5e6e71