### PR TITLE
Add missing g_object_ref_sink.

### DIFF
--- a/src/ibustext.c
+++ b/src/ibustext.c
@@ -249,6 +249,7 @@ ibus_text_append_attribute (IBusText *text,
 
     if (text->attrs == NULL) {
         text->attrs = ibus_attr_list_new ();
+        g_object_ref_sink (text->attrs);
     }
 
     attr = ibus_attribute_new (type, value, start_index, end_index);


### PR DESCRIPTION
When a text attribute list is created by ibus_text_append_attribute, it is not sinked and should be.