### PR TITLE
Provide preedit semantic APIs

### DIFF
--- a/bindings/vala/IBus-1.0-custom.vala
+++ b/bindings/vala/IBus-1.0-custom.vala
@@ -7,7 +7,8 @@ namespace IBus {
                 copy_format_to_hint () throws GLib.Error;
                 [Version (since = "1.5.33")]
                 public unowned IBus.AttrList
-                copy_format_to_rgba () throws GLib.Error;
+                copy_format_to_rgba (IBus.RGBA? selected_fg,
+                                     IBus.RGBA? selected_bg) throws GLib.Error;
         }
         public class EmojiData : IBus.Serializable {
 		[CCode (cname = "ibus_emoji_data_new",
@@ -18,6 +19,11 @@ namespace IBus {
 		[CCode (cname = "ibus_extension_event_new",
                         has_construct_function = true)]
 		public ExtensionEvent (string first_property_name, ...);
+	}
+        public class InputContext : IBus.Proxy {
+                [Version (since = "1.5.33")]
+                public void set_selected_color (IBus.RGBA fg_color,
+                                                IBus.RGBA bg_color);
 	}
 	public class Message : IBus.Serializable {
 		[CCode (cname = "ibus_message_new",
@@ -31,6 +37,9 @@ namespace IBus {
 	public class PanelService : IBus.Service {
                 public void
                 panel_extension_register_keys(string first_property_name, ...);
+                [Version (since = "1.5.33")]
+                public void set_selected_color (IBus.RGBA fg_color,
+                                                IBus.RGBA bg_color);
 	}
 	// For some reason, ibus_text_new_from_static_string is hidden in GIR
 	// https://github.com/ibus/ibus/commit/37e6e587

--- a/bindings/vala/IBus-1.0-custom.vala
+++ b/bindings/vala/IBus-1.0-custom.vala
@@ -1,4 +1,14 @@
 namespace IBus {
+        [CCode (cheader_filename = "ibusattrlistprivate.h",
+                type_id = "ibus_attr_list_get_type ()")]
+        public class AttrList : IBus.Serializable {
+                [Version (since = "1.5.33")]
+                public unowned IBus.AttrList
+                copy_format_to_hint () throws GLib.Error;
+                [Version (since = "1.5.33")]
+                public unowned IBus.AttrList
+                copy_format_to_rgba () throws GLib.Error;
+        }
         public class EmojiData : IBus.Serializable {
 		[CCode (cname = "ibus_emoji_data_new",
                         has_construct_function = true)]

--- a/bus/main.c
+++ b/bus/main.c
@@ -2,7 +2,7 @@
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
  * Copyright (C) 2008-2013 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2013-2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2013-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
  * Copyright (C) 2008-2023 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
@@ -228,6 +228,10 @@ main (gint argc, gchar **argv)
     setpgid (0, 0);
 
     ibus_init ();
+
+#ifndef HAVE_PRODUCT_BUILD
+    g_setenv ("PYTHONWARNINGS", "always", FALSE);
+#endif
 
     ibus_set_log_handler (g_verbose);
 

--- a/client/gtk2/Makefile.am
+++ b/client/gtk2/Makefile.am
@@ -3,7 +3,7 @@
 # ibus - The Input Bus
 #
 # Copyright (c) 2007-2010 Peng Huang <shawn.p.huang@gmail.com>
-# Copyright (c) 2007-2010 Red Hat, Inc.
+# Copyright (c) 2007-2025 Red Hat, Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -34,6 +34,8 @@ im_ibus_la_SOURCES = \
 	ibusim.c \
 	ibusimcontext.c \
 	ibusimcontext.h \
+	iconwidget.c \
+	iconwidget.h \
 	$(NULL)
 
 im_ibus_la_DEPENDENCIES = $(libibus)

--- a/client/gtk2/ibusimcontext.c
+++ b/client/gtk2/ibusimcontext.c
@@ -2214,6 +2214,9 @@ _ibus_context_update_preedit_text_cb (IBusInputContext  *ibuscontext,
                                         ((attr->value & 0x00ff00)) | 0xff,
                                         ((attr->value & 0x0000ff) << 8) | 0xff);
                 break;
+            case IBUS_ATTR_TYPE_HINT:
+                g_warning ("IBUS_ATTR_TYPE_HINT should not happen.");
+                continue;
             default:
                 continue;
             }
@@ -2345,8 +2348,7 @@ _create_input_context_done (IBusBus       *bus,
     if (context == NULL) {
         g_warning ("Create input context failed: %s.", error->message);
         g_error_free (error);
-    }
-    else {
+    } else {
         gboolean requested_surrounding_text = FALSE;
         ibus_input_context_set_client_commit_preedit (context, TRUE);
         if (_use_sync_mode == 1)

--- a/client/gtk2/iconwidget.c
+++ b/client/gtk2/iconwidget.c
@@ -1,0 +1,328 @@
+/* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
+/* vim:set et sts=4: */
+/* ibus - The Input Bus
+ * Copyright (C) 2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+#define GDK_DISABLE_DEPRECATION_WARNINGS
+#include <gtk/gtk.h>
+#undef GDK_DISABLE_DEPRECATION_WARNINGS
+
+#include "iconwidget.h"
+
+#define IBUS_THEMED_RGBA_GET_PRIVATE(o)  \
+   ((IBusThemedRGBAPrivate *)ibus_themed_rgba_get_instance_private (o))
+
+enum {
+    PROP_0 = 0,
+    PROP_STYLE_CONTEXT,
+    PROP_STYLE,
+};
+
+typedef struct _IBusThemedRGBAPrivate IBusThemedRGBAPrivate;
+struct _IBusThemedRGBAPrivate {
+#if GTK_CHECK_VERSION (2, 91, 0)
+    GtkStyleContext *style_context;
+#else
+    GtkStyle        *style;
+#endif
+};
+
+static void ibus_themed_rgba_set_property (IBusThemedRGBA *rgba,
+                                           guint           prop_id,
+                                           const GValue   *value,
+                                           GParamSpec     *pspec);
+static void ibus_themed_rgba_get_property (IBusThemedRGBA *rgba,
+                                           guint           prop_id,
+                                           GValue         *value,
+                                           GParamSpec     *pspec);
+static void ibus_themed_rgba_destroy      (IBusObject     *object);
+
+G_DEFINE_TYPE_WITH_PRIVATE (IBusThemedRGBA, ibus_themed_rgba, IBUS_TYPE_OBJECT)
+
+
+static void
+ibus_themed_rgba_class_init (IBusThemedRGBAClass *class)
+{
+    GObjectClass *gobject_class = G_OBJECT_CLASS (class);
+    IBusObjectClass *ibus_object_class = IBUS_OBJECT_CLASS (class);
+
+    gobject_class->set_property =
+            (GObjectSetPropertyFunc)ibus_themed_rgba_set_property;
+    gobject_class->get_property =
+            (GObjectGetPropertyFunc)ibus_themed_rgba_get_property;
+    ibus_object_class->destroy = ibus_themed_rgba_destroy;
+
+#if GTK_CHECK_VERSION (2, 91, 0)
+    /**
+     * IBusThemedRGBA:style-context:
+     *
+     * The GtkStyleContext of property
+     */
+    g_object_class_install_property (gobject_class,
+            PROP_STYLE_CONTEXT,
+            g_param_spec_object ("style-context",
+                    "style context",
+                    "The style context of property",
+                    GTK_TYPE_STYLE_CONTEXT,
+                    G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+#else
+    /**
+     * IBusThemedRGBA:style:
+     *
+     * The GtkStyle of property
+     */
+    g_object_class_install_property (gobject_class,
+            PROP_STYLE,
+            g_param_spec_pointer ("style",
+                    "style",
+                    "The style of property",
+                    G_PARAM_READWRITE | G_PARAM_CONSTRUCT));
+#endif
+}
+
+
+static void
+ibus_themed_rgba_init (IBusThemedRGBA *rgba)
+{
+}
+
+
+#if GTK_CHECK_VERSION (2, 91, 0)
+static IBusRGBA *
+ibus_rgba_new_with_gdk_rgba (GdkRGBA *gdk_rgba)
+{
+    IBusRGBA *ibus_rgba;
+
+    g_return_val_if_fail (gdk_rgba, NULL);
+    ibus_rgba = g_slice_new (IBusRGBA);
+    ibus_rgba->red = gdk_rgba->red;
+    ibus_rgba->green = gdk_rgba->green;
+    ibus_rgba->blue = gdk_rgba->blue;
+    ibus_rgba->alpha = gdk_rgba->alpha;
+    return ibus_rgba;
+}
+
+
+static IBusRGBA *
+ibus_rgba_new_with_style_context (GtkStyleContext *style_context,
+                                  const gchar     *theme_name,
+                                  const gchar     *regacy_theme_name,
+                                  const gchar     *fallback_rgba)
+{
+    GdkRGBA color = { 0, };
+    if (gtk_style_context_lookup_color (style_context, theme_name, &color)) {
+        ;
+    } else if (gtk_style_context_lookup_color (style_context,
+                                               regacy_theme_name,
+                                               &color)) {
+        ;
+    } else if (fallback_rgba) {
+        gdk_rgba_parse (&color, fallback_rgba);
+    }
+    return ibus_rgba_new_with_gdk_rgba (&color);
+}
+
+#else
+
+static IBusRGBA *
+ibus_rgba_new_with_gdk_color (GdkColor *gdk_color)
+{
+    IBusRGBA *ibus_rgba;
+
+    g_return_val_if_fail (gdk_color, NULL);
+    ibus_rgba = g_slice_new (IBusRGBA);
+    ibus_rgba->red = (float)gdk_color->red / 0xffff;
+    ibus_rgba->green = (float)gdk_color->green / 0xffff;
+    ibus_rgba->blue = (float)gdk_color->blue / 0xffff;
+    ibus_rgba->alpha = 1.; /* (float)gdk_color->pixel / 0xffff */
+    return ibus_rgba;
+}
+#endif
+
+
+static void
+ibus_themed_rgba_set_property (IBusThemedRGBA *rgba,
+                               guint           prop_id,
+                               const GValue   *value,
+                               GParamSpec     *pspec)
+{
+    IBusThemedRGBAPrivate *priv;
+
+    g_return_if_fail (IBUS_THEMED_RGBA (rgba));
+    priv = IBUS_THEMED_RGBA_GET_PRIVATE (rgba);
+    switch (prop_id) {
+#if GTK_CHECK_VERSION (2, 91, 0)
+    case PROP_STYLE_CONTEXT:
+        if (priv->style_context)
+            g_object_unref (priv->style_context);
+        priv->style_context = g_value_get_object (value);
+        if (priv->style_context) {
+            g_object_ref (priv->style_context);
+            ibus_themed_rgba_get_colors (rgba);
+        }
+        break;
+#else
+    case PROP_STYLE:
+        priv->style = g_value_get_pointer (value);
+        if (priv->style)
+            ibus_themed_rgba_get_colors (rgba);
+        break;
+#endif
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (rgba, prop_id, pspec);
+    }
+}
+
+
+static void
+ibus_themed_rgba_get_property (IBusThemedRGBA *rgba,
+                               guint           prop_id,
+                               GValue         *value,
+                               GParamSpec     *pspec)
+{
+    IBusThemedRGBAPrivate *priv;
+
+    g_return_if_fail (IBUS_THEMED_RGBA (rgba));
+    priv = IBUS_THEMED_RGBA_GET_PRIVATE (rgba);
+    switch (prop_id) {
+#if GTK_CHECK_VERSION (2, 91, 0)
+    case PROP_STYLE_CONTEXT:
+        if (priv->style_context) {
+            g_value_set_object (value,
+                                g_object_ref (priv->style_context));
+        }
+        break;
+#else
+    case PROP_STYLE:
+        if (priv->style)
+            g_value_set_pointer (value, priv->style);
+        break;
+#endif
+    default:
+        G_OBJECT_WARN_INVALID_PROPERTY_ID (rgba, prop_id, pspec);
+    }
+}
+
+
+static void
+ibus_themed_rgba_destroy (IBusObject *object)
+{
+    IBusThemedRGBA *rgba = (IBusThemedRGBA *)object;
+    IBusThemedRGBAPrivate *priv;
+
+    g_return_if_fail (IBUS_IS_THEMED_RGBA (rgba));
+    priv = IBUS_THEMED_RGBA_GET_PRIVATE (rgba);
+#if GTK_CHECK_VERSION (2, 91, 0)
+    g_clear_object (&priv->style_context);
+#else
+    priv->style = NULL;
+#endif
+
+    if (rgba->normal_fg) {
+        g_slice_free (IBusRGBA, rgba->normal_fg);
+        rgba->normal_fg = NULL;
+    }
+    if (rgba->normal_bg) {
+        g_slice_free (IBusRGBA, rgba->normal_bg);
+        rgba->normal_bg = NULL;
+    }
+    if (rgba->selected_fg) {
+        g_slice_free (IBusRGBA, rgba->selected_fg);
+        rgba->selected_fg = NULL;
+    }
+    if (rgba->selected_bg) {
+        g_slice_free (IBusRGBA, rgba->selected_bg);
+        rgba->selected_bg = NULL;
+    }
+}
+
+
+IBusThemedRGBA *
+#if GTK_CHECK_VERSION (2, 91, 0)
+ibus_themed_rgba_new (GtkStyleContext *style_context)
+#else
+ibus_themed_rgba_new (GtkStyle        *style)
+#endif
+{
+    return (IBusThemedRGBA *)g_object_new (IBUS_TYPE_THEMED_RGBA,
+#if GTK_CHECK_VERSION (2, 91, 0)
+                                           "style-context",
+                                           style_context,
+#else
+                                           "style",
+                                           style,
+#endif
+                                           NULL);
+}
+
+
+void
+ibus_themed_rgba_get_colors (IBusThemedRGBA *rgba)
+{
+    IBusThemedRGBAPrivate *priv;
+
+    g_return_if_fail (IBUS_IS_THEMED_RGBA (rgba));
+    priv = IBUS_THEMED_RGBA_GET_PRIVATE (rgba);
+    if (rgba->normal_fg) {
+        g_slice_free (IBusRGBA, rgba->normal_fg);
+        rgba->normal_fg = NULL;
+    }
+    if (rgba->normal_bg) {
+        g_slice_free (IBusRGBA, rgba->normal_bg);
+        rgba->normal_bg = NULL;
+    }
+    if (rgba->selected_fg) {
+        g_slice_free (IBusRGBA, rgba->selected_fg);
+        rgba->selected_fg = NULL;
+    }
+    if (rgba->selected_bg) {
+        g_slice_free (IBusRGBA, rgba->selected_bg);
+        rgba->selected_bg = NULL;
+    }
+#if GTK_CHECK_VERSION (2, 91, 0)
+    rgba->normal_fg = ibus_rgba_new_with_style_context (priv->style_context,
+                                                        "theme_fg_color",
+                                                        "fg_normal",
+                                                        "#2e3436");
+    rgba->normal_bg = ibus_rgba_new_with_style_context (priv->style_context,
+                                                        "theme_bg_color",
+                                                        "base_normal",
+                                                        "#f6f5f4");
+    rgba->selected_fg =
+            ibus_rgba_new_with_style_context (priv->style_context,
+                                              "theme_selected_fg_color",
+                                              "fg_selected",
+                                              "#ffffff");
+    rgba->selected_bg =
+            ibus_rgba_new_with_style_context (priv->style_context,
+                                              "theme_selected_bg_color",
+                                              "base_selected",
+                                              "#3584e4");
+#else
+    rgba->normal_fg = ibus_rgba_new_with_gdk_color (
+            &priv->style->fg[GTK_STATE_NORMAL]);
+    rgba->normal_bg = ibus_rgba_new_with_gdk_color (
+            &priv->style->base[GTK_STATE_NORMAL]);
+    rgba->selected_fg = ibus_rgba_new_with_gdk_color (
+            &priv->style->fg[GTK_STATE_SELECTED]);
+    rgba->selected_bg = ibus_rgba_new_with_gdk_color (
+            &priv->style->base[GTK_STATE_SELECTED]);
+#endif
+}

--- a/client/gtk2/iconwidget.h
+++ b/client/gtk2/iconwidget.h
@@ -1,0 +1,70 @@
+/* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
+/* vim:set et sts=4: */
+/* ibus - The Input Bus
+ * Copyright (C) 2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+#include <gtk/gtk.h>
+#include <ibus.h>
+
+#ifndef __IBUS_THEMED_RGBA_H_
+#define __IBUS_THEMED_RGBA_H_
+
+#define IBUS_TYPE_THEMED_RGBA                   \
+    (ibus_themed_rgba_get_type ())
+#define IBUS_THEMED_RGBA(obj)                   \
+    (G_TYPE_CHECK_INSTANCE_CAST ((obj), IBUS_TYPE_THEMED_RGBA, IBusThemedRGBA))
+#define IBUS_THEMED_RGBA_CLASS(klass)           \
+    (G_TYPE_CHECK_CLASS_CAST ((klass),          \
+                              IBUS_TYPE_THEMED_RGBA, \
+                              IBusThemedRGBAClass))
+#define IBUS_IS_THEMED_RGBA(obj)                \
+    (G_TYPE_CHECK_INSTANCE_TYPE ((obj), IBUS_TYPE_THEMED_RGBA))
+#define IBUS_IS_THEMED_RGBA_CLASS(klass)        \
+    (G_TYPE_CHECK_CLASS_TYPE ((klass), IBUS_TYPE_THEMED_RGBA))
+#define IBUS_THEMED_RGBA_GET_CLASS(obj)         \
+    (G_TYPE_INSTANCE_GET_CLASS ((obj),          \
+                                IBUS_TYPE_THEMED_RGBA, \
+                                IBusThemedRGBAClass))
+
+typedef struct _IBusThemedRGBA IBusThemedRGBA;
+typedef struct _IBusThemedRGBAClass IBusThemedRGBAClass;
+
+struct _IBusThemedRGBA {
+    IBusObject parent;
+    /* instance members */
+    IBusRGBA *normal_fg;
+    IBusRGBA *normal_bg;
+    IBusRGBA *selected_fg;
+    IBusRGBA *selected_bg;
+};
+
+struct _IBusThemedRGBAClass {
+    IBusObjectClass parent;
+};
+
+GType            ibus_themed_rgba_get_type     (void);
+#if GTK_CHECK_VERSION (2, 91, 0)
+IBusThemedRGBA  *ibus_themed_rgba_new          (GtkStyleContext *style_context);
+#else
+IBusThemedRGBA  *ibus_themed_rgba_new          (GtkStyle        *style);
+#endif
+void             ibus_themed_rgba_get_colors   (IBusThemedRGBA  *rgba);
+
+#endif

--- a/client/gtk3/Makefile.am
+++ b/client/gtk3/Makefile.am
@@ -3,7 +3,7 @@
 # ibus - The Input Bus
 #
 # Copyright (c) 2007-2010 Peng Huang <shawn.p.huang@gmail.com>
-# Copyright (c) 2007-2010 Red Hat, Inc.
+# Copyright (c) 2007-2025 Red Hat, Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -34,6 +34,8 @@ im_ibus_la_SOURCES = \
 	ibusim.c \
 	ibusimcontext.c \
 	ibusimcontext.h \
+	iconwidget.c \
+	iconwidget.h \
 	$(NULL)
 
 im_ibus_la_DEPENDENCIES = $(libibus)

--- a/client/gtk3/iconwidget.c
+++ b/client/gtk3/iconwidget.c
@@ -1,0 +1,1 @@
+../gtk2/iconwidget.c

--- a/client/gtk3/iconwidget.h
+++ b/client/gtk3/iconwidget.h
@@ -1,0 +1,1 @@
+../gtk2/iconwidget.h

--- a/client/gtk4/Makefile.am
+++ b/client/gtk4/Makefile.am
@@ -2,8 +2,8 @@
 #
 # ibus - The Input Bus
 #
-# Copyright (c) 2020 Takao Fujiwara <takao.fujiwara1@gmail.com>
-# Copyright (c) 2020 Red Hat, Inc.
+# Copyright (c) 2020-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2020-2025 Red Hat, Inc.
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -34,6 +34,8 @@ libim_ibus_la_SOURCES = \
 	ibusim.c \
 	ibusimcontext.c \
 	ibusimcontext.h \
+	iconwidget.c \
+	iconwidget.h \
 	$(NULL)
 
 libim_ibus_la_DEPENDENCIES = $(libibus)

--- a/client/gtk4/iconwidget.c
+++ b/client/gtk4/iconwidget.c
@@ -1,0 +1,1 @@
+../gtk2/iconwidget.c

--- a/client/gtk4/iconwidget.h
+++ b/client/gtk4/iconwidget.h
@@ -1,0 +1,1 @@
+../gtk2/iconwidget.h

--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -497,6 +497,9 @@ ibus_wayland_im_update_preedit_style (IBusWaylandIM *wlim)
             default:; /* Custom */
             }
             break;
+        case IBUS_ATTR_TYPE_HINT:
+            istyle = attr->value;
+            break;
         default:
             istyle = IBUS_ATTR_PREEDIT_NONE;
         }
@@ -1767,6 +1770,8 @@ _create_input_context_done (GObject      *object,
         ibus_input_context_set_capabilities (priv->ibuscontext,
                                              capabilities);
         ibus_input_context_set_client_commit_preedit (priv->ibuscontext, TRUE);
+        ibus_input_context_set_preedit_format (priv->ibuscontext,
+                                               IBUS_PREEDIT_FORMAT_HINT);
         if (_use_sync_mode == 1) {
             ibus_input_context_set_post_process_key_event (priv->ibuscontext,
                                                            TRUE);

--- a/configure.ac
+++ b/configure.ac
@@ -144,6 +144,26 @@ AC_SEARCH_LIBS([strerror],[cposix])
 
 LT_INIT
 
+AC_MSG_CHECKING([for product build])
+# --disable-product-build option.
+AC_ARG_ENABLE(product-build,
+    AS_HELP_STRING([--disable-product-build],
+                   [Disable CFLAGS for the product release]),
+    [enable_product_build="$enableval"],
+    [enable_product_build="auto"]
+)
+if test x"$enable_product_build" = xauto; then
+    if echo ibus_beta_version | grep -q "rc"; then
+        enable_product_build="yes"
+    else
+        enable_product_build="no"
+    fi
+fi
+if test x"$enable_product_build" = xyes; then
+    AC_DEFINE(HAVE_PRODUCT_BUILD, 1, [Enable product build])
+fi
+AC_MSG_RESULT([$enable_product_build])
+
 # Check header filess.
 AC_CHECK_HEADERS([sys/prctl.h])
 
@@ -153,6 +173,16 @@ AC_CHECK_FUNCS(daemon)
 # Check dlclose() in libc.so.
 AC_CHECK_LIB(c, dlclose, LIBDL="", [AC_CHECK_LIB(dl, dlclose, LIBDL="-ldl")])
 AC_SUBST(LIBDL)
+
+# Check if static build only
+AC_MSG_CHECKING([for IBUS_STATIC_COMPILATION])
+ibus_build_static_only=0
+if test "x$enable_static" = "xyes" -a "x$enable_shared" != "xyes" ; then
+    ibus_build_static_only=1
+    AC_DEFINE(IBUS_STATIC_COMPILATION, $ibus_build_static_only,
+              [Define to build static])
+fi
+AC_MSG_RESULT([$ibus_build_static_only])
 
 # Check if cross compiling.
 AM_CONDITIONAL(CROSS_COMPILING, test "x$cross_compiling" = xyes)

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -174,6 +174,7 @@ libibus_1_0_la_SOURCES = $(libibus_sources)
 ibusincludedir = $(includedir)/ibus-@IBUS_API_VERSION@
 ibus_public_headers =       \
     $(ibus_headers)         \
+    ibus-visibility.h       \
     ibusenumtypes.h         \
     ibusversion.h           \
     $(NULL)
@@ -181,6 +182,7 @@ ibusinclude_HEADERS =       \
     $(ibus_public_headers)  \
     $(NULL)
 ibus_private_headers =          \
+    ibusattrlistprivate.h       \
     ibuscomposetable.h          \
     ibusemojigen.h              \
     ibusenginesimpleprivate.h   \

--- a/src/ibus-visibility.h
+++ b/src/ibus-visibility.h
@@ -1,0 +1,73 @@
+/* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
+/* vim:set et sts=4: */
+/* IBus - The Input Bus
+ * Copyright (C) 2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+#if (defined(_WIN32) || defined(__CYGWIN__)) && !defined(IBUS_STATIC_COMPILATION)
+#  define _IBUS_EXPORT __declspec(dllexport)
+#  define _IBUS_IMPORT __declspec(dllimport)
+#elif __GNUC__ >= 4
+#  define _IBUS_EXPORT __attribute__((visibility("default")))
+#  define _IBUS_IMPORT
+#else
+#  define _IBUS_EXPORT
+#  define _IBUS_IMPORT
+#endif
+#ifdef IBUS_COMPILATION
+#  define _IBUS_API _IBUS_EXPORT
+#else
+#  define _IBUS_API _IBUS_IMPORT
+#endif
+
+#define _IBUS_EXTERN _IBUS_API extern
+
+#define IBUS_ENCODE_VERSION(major, minor, micro) ((major) << 16 | \
+                                                  (minor) << 8  | \
+                                                  (micro))
+
+#define IBUS_VERSION_CUR_STABLE (IBUS_ENCODE_VERSION (IBUS_MAJOR_VERSION, \
+                                                      IBUS_MINOR_VERSION, \
+                                                      IBUS_MICRO_VERSION))
+
+#ifndef IBUS_VERSION_MIN_REQUIRED
+#define IBUS_VERSION_MIN_REQUIRED (IBUS_VERSION_CUR_STABLE)
+#elif IBUS_VERSION_MIN_REQUIRED == 0
+#undef IBUS_VERSION_MIN_REQUIRED
+#define IBUS_VERSION_MIN_REQUIRED (IBUS_VERSION_CUR_STABLE + 1)
+#endif
+
+#ifdef IBUS_DISABLE_DEPRECATION_WARNINGS
+#define IBUS_DEPRECATED _IBUS_EXTERN
+#define IBUS_DEPRECATED_FOR(f) _IBUS_EXTERN
+#else
+#define IBUS_DEPRECATED G_DEPRECATED _IBUS_EXTERN
+#define IBUS_DEPRECATED_FOR(f) G_DEPRECATED_FOR(f) _IBUS_EXTERN
+#endif
+
+
+#define IBUS_VERSION_1_5_33     (IBUS_ENCODE_VERSION (1, 5, 33))
+
+#if IBUS_VERSION_MIN_REQUIRED >= IBUS_VERSION_1_5_33
+#define IBUS_DEPRECATED_IN_1_5_33 IBUS_DEPRECATED
+#define IBUS_DEPRECATED_IN_1_5_33_FOR(f) IBUS_DEPRECATED_FOR (f)
+#else
+#define IBUS_DEPRECATED_IN_1_5_33 _IBUS_EXTERN
+#define IBUS_DEPRECATED_IN_1_5_33_FOR(f) _IBUS_EXTERN
+#endif

--- a/src/ibusattribute.c
+++ b/src/ibusattribute.c
@@ -2,7 +2,7 @@
 /* vim:set et sts=4: */
 /* IBus - The Input Bus
  * Copyright (C) 2008-2010 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2008-2010 Red Hat, Inc.
+ * Copyright (C) 2008-2025 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -19,6 +19,11 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
  * USA
  */
+
+#ifdef HAVE_CONFIG_H
+#include <config.h>
+#endif
+
 #include "ibusattribute.h"
 
 /* functions prototype */
@@ -112,7 +117,8 @@ ibus_attribute_new (guint type,
     g_return_val_if_fail (
         type == IBUS_ATTR_TYPE_UNDERLINE  ||
         type == IBUS_ATTR_TYPE_FOREGROUND ||
-        type == IBUS_ATTR_TYPE_BACKGROUND, NULL);
+        type == IBUS_ATTR_TYPE_BACKGROUND ||
+        type == IBUS_ATTR_TYPE_HINT, NULL);
 
     IBusAttribute *attr = IBUS_ATTRIBUTE (g_object_new (IBUS_TYPE_ATTRIBUTE, NULL));
 
@@ -187,4 +193,14 @@ ibus_attr_background_new (guint color,
                                end_index);
 }
 
-
+IBusAttribute *
+ibus_attr_hint_new (guint hint,
+                    guint start_index,
+                    guint end_index)
+{
+    g_return_val_if_fail (hint != IBUS_ATTR_PREEDIT_NONE, NULL);
+    return ibus_attribute_new (IBUS_ATTR_TYPE_HINT,
+                               hint,
+                               start_index,
+                               end_index);
+}

--- a/src/ibusattrlistprivate.h
+++ b/src/ibusattrlistprivate.h
@@ -30,6 +30,10 @@
 /**
  * ibus_attr_list_copy_format_to_rgba:
  * @attr_list: An #IBusAttrList instance.
+ * @selected_fg: (nullable): A const IBusRGBA value of the selected foreground
+ *                           color.
+ * @selected_bg: (nullable): A const IBusRGBA value of the selected background
+ *                           color.
  * @error: An #GError pointer.
  *
  * Returns: (transfer none): A newly allocated #IBusAttrList which includes the
@@ -41,8 +45,10 @@
  * Stability: Unstable
  */
 IBusAttrList        *ibus_attr_list_copy_format_to_rgba
-                                                (IBusAttrList *attr_list,
-                                                 GError      **error);
+                                                (IBusAttrList   *attr_list,
+                                                 const IBusRGBA *selected_fg,
+                                                 const IBusRGBA *selected_bg,
+                                                 GError         **error);
 
 /**
  * ibus_attr_list_copy_format_to_hint:
@@ -59,4 +65,56 @@ IBusAttrList        *ibus_attr_list_copy_format_to_rgba
 IBusAttrList        *ibus_attr_list_copy_format_to_hint
                                                 (IBusAttrList *attr_list,
                                                  GError      **error);
+
+#ifdef __IBUS_INPUT_CONTEXT_H_
+/**
+ * ibus_input_context_set_selected_color:
+ * @context: An #IBusInputContext.
+ * @fg_color: An #IBusRGBA.
+ * @bg_color: An #IBusRGBA.
+ *
+ * Set a selected background color of a text view widget with a desktop theme.
+ * Xorg desktop sessions use RGBA values for the pre-edit color in each
+ * #IBusInputContext traditionally.
+ * In case an #IBusEngine uses #IBUS_ATTR_TYPE_HINT type for
+ * the #IBusAttribute of the pre-edit, #IBusInputContext needs to convert
+ * the hint to the actual RGBA values and the @fg_color and @bg_color are
+ * used for the selected segment in the pre-edit text.
+ *
+ * See also ibus_attr_hint_new();
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+void          ibus_input_context_set_selected_color
+                                            (IBusInputContext   *context,
+                                             const IBusRGBA     *fg_color,
+                                             const IBusRGBA     *bg_color);
+#endif
+
+#ifdef __IBUS_PANEL_SERVICE_H_
+/**
+ * ibus_panel_service_set_selected_color:
+ * @panel: An #IBusPanelService.
+ * @fg_color: A const #IBusRGBA of the selected foreground color.
+ * @bg_color: A const #IBusRGBA of the selected background color.
+ *
+ * Set a selected background color of a text view widget with a desktop theme.
+ * Xorg desktop sessions use RGBA values for the pre-edit color in each
+ * #IBusInputContext traditionally.
+ * In case an #IBusEngine uses #IBUS_ATTR_TYPE_HINT type for
+ * the #IBusAttribute of the pre-edit, #IBusInputContext needs to convert
+ * the hint to the actual RGBA values and the @fg_color and @bg_color are
+ * used for the selected segment in the pre-edit text.
+ *
+ * See also ibus_attr_hint_new();
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+void ibus_panel_service_set_selected_color
+                                          (IBusPanelService *panel,
+                                           const IBusRGBA   *fg_color,
+                                           const IBusRGBA   *bg_color);
+#endif
 #endif

--- a/src/ibusattrlistprivate.h
+++ b/src/ibusattrlistprivate.h
@@ -1,0 +1,62 @@
+/* -*- mode: C; c-basic-offset: 4; indent-tabs-mode: nil; -*- */
+/* vim:set et sts=4: */
+/* IBus - The Input Bus
+ * Copyright (C) 2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2025 Red Hat, Inc.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+ * USA
+ */
+
+#ifndef __IBUS_ATTRIBUTE_LIST_PRIVATE_H_
+#define __IBUS_ATTRIBUTE_LIST_PRIVATE_H_
+
+#define __IBUS_H_INSIDE__
+#include "ibusattrlist.h"
+#undef __IBUS_H_INSIDE__
+
+/**
+ * ibus_attr_list_copy_format_to_rgba:
+ * @attr_list: An #IBusAttrList instance.
+ * @error: An #GError pointer.
+ *
+ * Returns: (transfer none): A newly allocated #IBusAttrList which includes the
+ * RGBA #IBusAttribute with the type of @IBUS_ATTR_TYPE_UNDERLINE,
+ * @IBUS_ATTR_TYPE_FOREGROUND, @IBUS_ATTR_TYPE_BACKGROUND, or %NULL.
+ * Workaround: returned value will be unref with ibus_text_set_attributes().
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+IBusAttrList        *ibus_attr_list_copy_format_to_rgba
+                                                (IBusAttrList *attr_list,
+                                                 GError      **error);
+
+/**
+ * ibus_attr_list_copy_format_to_hint:
+ * @attr_list: An #IBusAttrList instance.
+ * @error: An #GError pointer.
+ *
+ * Returns: (transfer none): A newly allocated #IBusAttrList which includes the
+ * hint #IBusAttribute with the type of @IBUS_ATTR_TYPE_HINT, or %NULL.
+ * Workaround: returned value will be unref with ibus_text_set_attributes().
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+IBusAttrList        *ibus_attr_list_copy_format_to_hint
+                                                (IBusAttrList *attr_list,
+                                                 GError      **error);
+#endif

--- a/src/ibusinputcontext.h
+++ b/src/ibusinputcontext.h
@@ -2,8 +2,8 @@
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
  * Copyright (C) 2008-2013 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2018-2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
- * Copyright (C) 2008-2018 Red Hat, Inc.
+ * Copyright (C) 2018-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2008-2025 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -551,5 +551,25 @@ void         ibus_input_context_set_post_process_key_event
 void         ibus_input_context_post_process_key_event
                                             (IBusInputContext   *context);
 
+/**
+ * ibus_input_context_set_preedit_format:
+ * @context: An #IBusInputContext.
+ * @format: An #IBusPreeditFormat.
+ *
+ * The pre-edit attributes follows the format and the default is
+ * #IBUS_PREEDIT_FORMAT_RGBA and the types of all #IBusAttribute are should be
+ * one of  #IBUS_ATTR_TYPE_UNDERLINE, #IBUS_ATTR_TYPE_FOREGROUND,
+ * #IBUS_ATTR_TYPE_BACKGROUND.
+ * In case that the format is #IBUS_PREEDIT_FORMAT_HINT, the types of all
+ * #IBusAttribute are #IBUS_ATTR_TYPE_HINT.
+ *
+ * See also ibus_text_get_attributes();
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+void         ibus_input_context_set_preedit_format
+                                            (IBusInputContext   *context,
+                                             IBusPreeditFormat   format);
 G_END_DECLS
 #endif

--- a/src/ibuspanelservice.h
+++ b/src/ibuspanelservice.h
@@ -414,5 +414,26 @@ void ibus_panel_service_forward_process_key_event
  */
 void ibus_panel_service_send_message      (IBusPanelService *panel,
                                            IBusMessage      *message);
+
+/**
+ * ibus_panel_service_set_preedit_format:
+ * @panel: An #IBusPanelService.
+ * @format: An #IBusPreeditFormat.
+ *
+ * The pre-edit attributes follows the format and the default is
+ * #IBUS_PREEDIT_FORMAT_RGBA and the types of all #IBusAttribute are should be
+ * one of  #IBUS_ATTR_TYPE_UNDERLINE, #IBUS_ATTR_TYPE_FOREGROUND,
+ * #IBUS_ATTR_TYPE_BACKGROUND.
+ * In case that the format is #IBUS_PREEDIT_FORMAT_HINT, the types of all
+ * #IBusAttribute are #IBUS_ATTR_TYPE_HINT.
+ *
+ * See also ibus_text_get_attributes();
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+void ibus_panel_service_set_preedit_format
+                                          (IBusPanelService *panel,
+                                           IBusPreeditFormat format);
 G_END_DECLS
 #endif

--- a/src/ibusshare.h
+++ b/src/ibusshare.h
@@ -2,8 +2,8 @@
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
  * Copyright (C) 2008-2013 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2015-2022 Takao Fujiwara <takao.fujiwara1@gmail.com>
- * Copyright (C) 2008-2022 Red Hat, Inc.
+ * Copyright (C) 2015-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright (C) 2008-2025 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -38,12 +38,6 @@
  */
 
 #include <glib.h>
-
-#ifdef IBUS_DISABLE_DEPRECATION_WARNINGS
-#define IBUS_DEPRECATED
-#else
-#define IBUS_DEPRECATED G_DEPRECATED
-#endif
 
 /**
  * IBUS_SERVICE_IBUS:

--- a/src/ibustypes.h
+++ b/src/ibustypes.h
@@ -231,6 +231,26 @@ struct _IBusRectangle {
 };
 
 /**
+ * IBusRGBA:
+ * @red: Red value.
+ * @green: Green value.
+ * @blue: Blue value.
+ * @alpha: Alpha value.
+ *
+ * RGBA definition.
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+typedef struct __IBusRGBA IBusRGBA;
+struct __IBusRGBA {
+    float red;
+    float green;
+    float blue;
+    float alpha;
+};
+
+/**
  * IBusFreeFunc:
  * @object: object to be freed.
  *

--- a/src/ibustypes.h
+++ b/src/ibustypes.h
@@ -358,6 +358,7 @@ typedef enum
         IBUS_SUPER_MASK |                       \
         IBUS_HYPER_MASK |                       \
         IBUS_META_MASK))
+
 /**
  * IBusMessageDomain:
  * @IBUS_MESSAGE_ENGINE: The message domain for Engine messages
@@ -372,5 +373,28 @@ typedef enum
   IBUS_MESSAGE_DOMAIN_ENGINE,
   IBUS_MESSAGE_DOMAIN_PANEL
 } IBusMessageDomain;
+
+/**
+ * IBusPreeditFormat:
+ * @IBUS_PREEDIT_FORMAT_RGBA: Use #IBusAttribute with the RGBA.
+ *         This has been a default usage and ibus_attribute_get_attr_type()
+ *         returns @IBUS_ATTR_TYPE_UNDERLINE, @IBUS_ATTR_TYPE_FOREGROUND,
+ *         @IBUS_ATTR_TYPE_BACKGROUND.
+ * @IBUS_PREEDIT_FORMAT_HINT: Use #IBusAttribute with the hints.
+ *         This let #IBusPanelService decides the actual RGBA values to follow
+ *         the current desktop theme and ibus_attribute_get_attr_type()
+ *         returns @IBUS_ATTR_TYPE_HINT.
+ *
+ * You can set the "preedit-format" property of the constructor of
+ * #IBusInputContext or #IBusPanelService.
+ *
+ * Since: 1.5.33
+ * Stability: Unstable
+ */
+typedef enum
+{
+    IBUS_PREEDIT_FORMAT_RGBA,
+    IBUS_PREEDIT_FORMAT_HINT,
+} IBusPreeditFormat;
 
 #endif

--- a/src/ibusversion.h.in
+++ b/src/ibusversion.h.in
@@ -1,7 +1,7 @@
 /* vim:set et sts=4: */
 /* ibus - The Input Bus
  * Copyright (C) 2008-2010 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright (C) 2008-2010 Red Hat, Inc.
+ * Copyright (C) 2008-2025 Red Hat, Inc.
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -68,5 +68,7 @@
      (IBUS_MAJOR_VERSION == (major) && IBUS_MINOR_VERSION == (minor) && \
       IBUS_MICRO_VERSION >= (micro)))
 
+#include <glib.h>
+#include <ibus-visibility.h>
 #endif
 

--- a/ui/gtk3/candidatearea.vala
+++ b/ui/gtk3/candidatearea.vala
@@ -3,7 +3,7 @@
  * ibus - The Input Bus
  *
  * Copyright(c) 2011-2015 Peng Huang <shawn.p.huang@gmail.com>
- * Copyright(c) 2015-2024 Takao Fujiwara <takao.fujiwara1@gmail.com>
+ * Copyright(c) 2015-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
  *
  * This library is free software; you can redistribute it and/or
  * modify it under the terms of the GNU Lesser General Public
@@ -23,6 +23,7 @@
 
 class CandidateArea : Gtk.Box {
     private bool m_vertical;
+    private Gtk.Widget m_text_view;
     private Gtk.Label[] m_labels;
     private Gtk.Label[] m_candidates;
     private Gtk.Widget[] m_widgets;
@@ -58,7 +59,18 @@ class CandidateArea : Gtk.Box {
     public CandidateArea(bool vertical) {
         GLib.Object();
         set_vertical(vertical, true);
-        m_rgba = new ThemedRGBA(this);
+        m_text_view = new Gtk.TextView();
+        var style_context = m_text_view.get_style_context();
+        m_rgba = new ThemedRGBA(style_context);
+    }
+
+    ~CandidateArea() {
+        m_ibus_candidates = null;
+        m_labels = null;
+        m_candidates = null;
+        m_widgets = null;
+        m_rgba = null;
+        m_text_view = null;
     }
 
     public bool candidate_scrolled(Gdk.EventScroll event) {

--- a/ui/gtk3/emojier.vala
+++ b/ui/gtk3/emojier.vala
@@ -315,6 +315,7 @@ public class IBusEmojier : Gtk.ApplicationWindow {
 
     private bool m_is_wayland;
     private bool m_is_gnome = false;
+    private Gtk.Widget m_text_view;
     private ThemedRGBA m_rgba;
     private Gtk.Box m_vbox;
     /* If emojier is emoji category list or Unicode category list,
@@ -427,6 +428,12 @@ public class IBusEmojier : Gtk.ApplicationWindow {
         }
 
         get_load_progress_object();
+    }
+
+
+    ~IBusEmojier() {
+        m_rgba = null;
+        m_text_view = null;
     }
 
 
@@ -841,8 +848,12 @@ public class IBusEmojier : Gtk.ApplicationWindow {
               }
           }
         }
-        if (m_rgba == null)
-            m_rgba = new ThemedRGBA(this);
+        if (m_text_view  == null)
+            m_text_view = new Gtk.TextView();
+        if (m_rgba == null) {
+            var style_context = m_text_view.get_style_context();
+            m_rgba = new ThemedRGBA(style_context);
+        }
         uint bg_red = (uint)(m_rgba.normal_bg.red * 255);
         uint bg_green = (uint)(m_rgba.normal_bg.green * 255);
         uint bg_blue = (uint)(m_rgba.normal_bg.blue * 255);

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -415,8 +415,6 @@ class Panel : IBus.PanelService {
             warning ("XDG_CURRENT_DESKTOP is not exported in your desktop " +
                      "session.");
         }
-        warning ("If you launch KDE5 on xterm, " +
-                 "export XDG_CURRENT_DESKTOP=KDE before launch KDE5.");
         return false;
     }
 
@@ -1060,10 +1058,10 @@ class Panel : IBus.PanelService {
         try {
             notification.show();
         } catch (GLib.Error e) {
-            warning (message);
+            warning(message);
         }
 #else
-        warning (message);
+        warning(message);
 #endif
     }
 


### PR DESCRIPTION
ibus_attr_hint_new() API and IBusPanelService:preedit-format property are provided and other ibus_attr_underline_new(),
ibus_attr_foreground_new() and ibus_attr_foreground_new() are deprecated so that IBus panel or the Wayland panels decide the actual preedit colors with the current desktop theme.

Ref: https://github.com/ibus/ibus/wiki/Wayland-Colors