### PR TITLE
src/ibusobservedpath.c: ~ expansion is needed in ibus_observed_path_fill_stat()

### DIFF
--- a/src/ibusobservedpath.c
+++ b/src/ibusobservedpath.c
@@ -309,9 +309,18 @@ ibus_observed_path_fill_stat (IBusObservedPath *path)
 {
     g_assert (IBUS_IS_OBSERVED_PATH (path));
 
+    gchar *real_path = NULL;
     struct stat buf;
 
-    if (g_stat (path->path, &buf) == 0) {
+    if (path->path[0] == '~') {
+        const gchar *homedir = g_get_home_dir ();
+        real_path = g_build_filename (homedir, path->path + 2, NULL);
+    }
+    else {
+        real_path = g_strdup (path->path);
+    }
+
+    if (g_stat (real_path, &buf) == 0) {
         path->is_exist = 1;
         if (S_ISDIR (buf.st_mode)) {
             path->is_dir = 1;


### PR DESCRIPTION
Currently, the mtime of files or directories in observed-paths which start with a `~`  is **always** 0, no matter whether they exist or not and no matter whether something changed there or not. For example:

```
(base) mfabian@hathi:/local/mfabian/src/ibus (observed-path-tilde *$%)
$ ibus read-cache | grep mtime 
        <path mtime="1756572087" type="dir" path="/usr/share/ibus/component">
                <path mtime="1737072000" >/usr/share/ibus/component/libzhuyin.xml</path>
                <path mtime="1750896000" >/usr/share/ibus/component/dconf.xml</path>
                <path mtime="1737072000" >/usr/share/ibus/component/kkc.xml</path>
                <path mtime="1756367111" >/usr/share/ibus/component/simple.xml</path>
                <path mtime="1737072000" >/usr/share/ibus/component/sayura.xml</path>
                <path mtime="1739836800" >/usr/share/ibus/component/anthy.xml</path>
                <path mtime="0" >~/.config/ibus-anthy/engines.xml</path>
                <path mtime="1739836800" >/usr/share/ibus-anthy/engine/default.xml</path>
                <path mtime="1737072000" >/usr/share/ibus/component/mozc.xml</path>
                <path mtime="1736899200" >/usr/share/ibus/component/stt.xml</path>
                <path mtime="1745778627" >/usr/share/ibus-stt</path>
                <path mtime="1745778627" >/usr/share/ibus-stt/formatting</path>
                <path mtime="1745778627" >/usr/share/ibus-stt/numbers</path>
                <path mtime="1754697600" >/usr/share/ibus/component/table.xml</path>
                <path mtime="1754764688" >/usr/share/ibus-table/tables/</path>
                <path mtime="1750896000" >/usr/share/ibus/component/gtkextension.xml</path>
                <path mtime="1698138400" >/usr/share/ibus/component/hiragana.xml</path>
                <path mtime="1737072000" >/usr/share/ibus/component/uniemoji.xml</path>
                <path mtime="1753747200" >/usr/share/ibus/component/typing-booster.xml</path>
                <path mtime="1757432450" >/usr/share/ibus-typing-booster/data/</path>
                <path mtime="1757446041" >/usr/share/ibus-typing-booster/data/annotationsDerived</path>
                <path mtime="1757446041" >/usr/share/ibus-typing-booster/data/annotations</path>
                <path mtime="0" >/usr/local/share/m17n/</path>
                <path mtime="1749571828" >/usr/share/m17n/</path>
                <path mtime="1745777823" >/usr/share/m17n/icons</path>
                <path mtime="1745777802" >/usr/share/m17n/scripts</path>
                <path mtime="0" >~/.m17n.d/</path>
                <path mtime="1737072000" >/usr/share/ibus/component/org.freedesktop.cangjie.ibus.Quick.xml</path>
                <path mtime="1737072000" >/usr/share/ibus/component/hangul.xml</path>
                <path mtime="1755993600" >/usr/share/ibus/component/chewing.xml</path>
                <path mtime="1737072000" >/usr/share/ibus/component/org.freedesktop.cangjie.ibus.Cangjie.xml</path>
                <path mtime="1743984000" >/usr/share/ibus/component/m17n.xml</path>
                <path mtime="1749571828" >/usr/share/m17n/</path>
                <path mtime="1745777823" >/usr/share/m17n/icons</path>
                <path mtime="1745777802" >/usr/share/m17n/scripts</path>
                <path mtime="1749552043" >/usr/share/ibus-m17n/default.xml</path>
                <path mtime="0" >~/.m17n.d/</path>
                <path mtime="1751983814" >/usr/share/ibus/component/braille.xml</path>
                <path mtime="1750896000" >/usr/share/ibus/component/gtkpanel.xml</path>
                <path mtime="1750723200" >/usr/share/ibus/component/libpinyin.xml</path>
                <path mtime="0" >~/.config/ibus/libpinyin/engines.xml</path>
                <path mtime="1750723200" >/usr/share/ibus-libpinyin/default.xml</path>
                <path mtime="1737072000" >/usr/share/ibus/component/unikey.xml</path>
                <path mtime="1660579645" >/usr/share/ibus/component/openbangla.xml</path>
(base) mfabian@hathi:/local/mfabian/src/ibus (observed-path-tilde *$%)
$ ls ~/.config/ibus-anthy/engines.xml
ls: '/home/mfabian/.config/ibus-anthy/engines.xml' にアクセスできません: そのようなファイルやディレクトリはありません
(base) mfabian@hathi:/local/mfabian/src/ibus (observed-path-tilde *$%)
$ ls /usr/local/share/m17n/
ls: '/usr/local/share/m17n/' にアクセスできません: そのようなファイルやディレクトリはありません
(base) mfabian@hathi:/local/mfabian/src/ibus (observed-path-tilde *$%)
$ ls ~/.m17n.d/
 bn-bijoyClassic.mim       config.mic-20250504   ipa-x-sampa.mim         mdb.dir                  test-savannah-67107-2.mim       test.mim.~3~           yi-telmac.mim
 bn-bijoyUnicode.mim       config.mic.~1~        ispell.mim              nil-mike.mim             test-savannah-67107-2.mim.~1~   test.mim.~4~
'bn-khipro(old).mim'       cop-greek-kbd.mim     ja-skip.mim             russian-elecom.mim       test-savannah-67107.mim         tokipona.mim
 bn-khipro-26.2.mim@       cuneiform.mim@        latex.mim               t-test-mike.mim          test-savannah-67107.mim.~1~     tokipona.mim.orig
 bn-national-jatiya.mim@   emoticon-table.mim    latn-pre.mim            te-itrans-itt533.mim     test.mim                        unicode-names.mim
 config.mic                german-mike.mim       lean-multi-choice.mim   test-issue-746.mim       test.mim.~1~                    vi-telex-mcsinyx.mim
 config.mic-20220831       icons/                lean.mim                test-issue-746.mim.~1~   test.mim.~2~                    xsampa.mim
(base) mfabian@hathi:/local/mfabian/src/ibus (observed-path-tilde *$%)
```
I.e. for `~/.config/ibus-anthy/engines.xml`  and `/usr/local/share/m17n/` it is OK that the mtime is 0 because they don't exist. 

But `~/.m17n.d/` **does** exist, so the real mtime should be used. 

The reason why getting the mtime fails is that `~` is not expanded before calling `g_stat ()`.

This pull request fixes this problem. 
