### PR TITLE
bus: Update gdm bits based on new gdm changes

### DIFF
--- a/bus/services/org.freedesktop.IBus.session.GNOME.service.in
+++ b/bus/services/org.freedesktop.IBus.session.GNOME.service.in
@@ -12,9 +12,6 @@ Before=gnome-session.target
 After=gnome-session-initialized.target
 PartOf=gnome-session-initialized.target
 
-# Never run in GDM
-Conflicts=gnome-session@gnome-login.target
-
 [Service]
 Type=dbus
 # Only pull --xim in X11 session, it is done via Xwayland-session.d on Wayland


### PR DESCRIPTION
Since GDM 49 version, gdm user doesn't exist and for each greeter there's a dynamic user creation, e.g. gdm-greeter-1, gdm-greeter-2. All of them are part of gdm group, so instead of checking for a specific user, check for a specific group.

Also, remove Conflicts in systemd service to allow ibus in GDM sessions. This covers some cases where users might have special characters in their password or username.

Reference: https://gitlab.gnome.org/GNOME/gdm/-/issues/1018.