### PR TITLE
bus: Update gdm bits based on new gdm changes

### DIFF
--- a/bus/main.c
+++ b/bus/main.c
@@ -39,6 +39,7 @@
 
 #ifdef G_OS_UNIX
 #include <glib-unix.h>
+#include <grp.h>
 #endif
 
 #include "global.h"
@@ -56,9 +57,11 @@ static gchar *config = "default";
 static gchar *desktop = "gnome";
 
 static gchar *panel_extension_disable_users[] = {
-    "gdm",
     "gnome-initial-setup",
     "liveuser"
+};
+static gchar *panel_extension_disable_groups[] = {
+    "gdm",
 };
 
 static void
@@ -184,6 +187,11 @@ main (gint argc, gchar **argv)
 {
     int i;
     const gchar *username = ibus_get_user_name ();
+    const gchar *groupname = NULL;
+#ifdef HAVE_GETGRGID_R
+    char buffer[4096];
+    struct group gbuf;
+#endif
 
     setlocale (LC_ALL, "");
 
@@ -214,6 +222,23 @@ main (gint argc, gchar **argv)
             g_printerr ("Please run ibus-daemon with login user! Do not run ibus-daemon with sudo or su.\n");
             exit (-1);
         }
+    }
+
+    /* get group name */
+    {
+        struct group *grp = NULL;
+#ifdef HAVE_GETGRGID_R
+        /* MT-Safe locale */
+        getgrgid_r (getgid (), &gbuf, buffer, sizeof(buffer), &grp);
+#else
+        /* MT-Unsafe race:grgid locale */
+        grp = getgrgid (getgid ());
+#endif
+
+        if (grp && grp->gr_name && grp->gr_name[0])
+            groupname = grp->gr_name;
+        else
+            g_warning ("Couldn't get group name");
     }
 
     /* daemonize process */
@@ -255,6 +280,12 @@ main (gint argc, gchar **argv)
     bus_server_init ();
     for (i = 0; i < G_N_ELEMENTS(panel_extension_disable_users); i++) {
         if (!g_strcmp0 (username, panel_extension_disable_users[i]) != 0) {
+            emoji_extension = "disable";
+            break;
+        }
+    }
+    for (i = 0; i < G_N_ELEMENTS(panel_extension_disable_groups); i++) {
+        if (g_strcmp0 (groupname, panel_extension_disable_groups[i]) == 0) {
             emoji_extension = "disable";
             break;
         }

--- a/bus/services/org.freedesktop.IBus.session.GNOME.service.in
+++ b/bus/services/org.freedesktop.IBus.session.GNOME.service.in
@@ -12,9 +12,6 @@ Before=gnome-session.target
 After=gnome-session-initialized.target
 PartOf=gnome-session-initialized.target
 
-# Never run in GDM
-Conflicts=gnome-session@gnome-login.target
-
 [Service]
 Type=dbus
 # Only pull --xim in X11 session, it is done via Xwayland-session.d on Wayland

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,7 @@ AC_MSG_RESULT([$enable_product_build])
 AC_CHECK_HEADERS([sys/prctl.h])
 
 # Check functions.
-AC_CHECK_FUNCS(daemon)
+AC_CHECK_FUNCS(daemon getgrgid_r)
 
 # Check dlclose() in libc.so.
 AC_CHECK_LIB(c, dlclose, LIBDL="", [AC_CHECK_LIB(dl, dlclose, LIBDL="-ldl")])


### PR DESCRIPTION
Since GDM 49 version, gdm user doesn't exist and for each greeter there's a dynamic user creation, e.g. gdm-greeter-1, gdm-greeter-2. All of them are part of gdm group, so instead of checking for a specific user, we check for a specific group.

Also, remove Conflicts in systemd service to allow ibus in GDM sessions. This covers some cases where users might have special characters in their password or username.

BUG=https://gitlab.gnome.org/GNOME/gdm/-/issues/1018
BUG=https://github.com/ibus/ibus/pull/2804