### PR TITLE
bus/inputcontext: Fix reset signal w/ GTK_IM_MODULE=ibus in Wayland

### DIFF
--- a/bus/inputcontext.c
+++ b/bus/inputcontext.c
@@ -1305,8 +1305,10 @@ _ic_focus_out (BusInputContext       *context,
                GDBusMethodInvocation *invocation)
 {
     if (context->capabilities & IBUS_CAP_FOCUS) {
-        if (context->ignore_focus_out)
+        if (context->ignore_focus_out) {
+            g_dbus_method_invocation_return_value (invocation, NULL);
             return;
+        }
         bus_input_context_focus_out (context);
         g_dbus_method_invocation_return_value (invocation, NULL);
     }
@@ -1329,6 +1331,10 @@ _ic_reset (BusInputContext       *context,
            GDBusMethodInvocation *invocation)
 {
     if (context->engine) {
+        if (context->ignore_focus_out) {
+            g_dbus_method_invocation_return_value (invocation, NULL);
+            return;
+        }
         if (context->preedit_mode == IBUS_ENGINE_PREEDIT_COMMIT) {
             if (context->client_commit_preedit)
                bus_input_context_clear_preedit_text (context, FALSE);


### PR DESCRIPTION
Some applications sends the reset signal when the focus is changed in case that the IBus candidate popup takes the focus with non-Wayland applications likes XIM and GTK2 in Wayland, and also GTK_IM_MODULE=ibus with GTK3 and GTK4. The most IBus engines clear the lookup table with the reset signal so ibus-daemon needs to ignore the reset signal besides the focus-out signal for non-Wayland applications.

Also fix a memory leak in the D-Bus method.

Fixes: https://github.com/ibus/ibus/commit/e27acd3 Fixes: https://github.com/ibus/ibus/commit/1b67352 BUG=https://github.com/ibus/ibus/issues/2803