### PR TITLE
ui/gtk3: don't build in parallel

### DIFF
--- a/ui/gtk3/Makefile.am
+++ b/ui/gtk3/Makefile.am
@@ -317,6 +317,8 @@ panelbinding.o: $(srcdir)/panelbinding.c
 	$(AM_V_CC_no)$(COMPILE) -c -o $@ $<
 	$(NULL)
 
+.NOTPARALLEL:
+
 MAINTAINERCLEANFILES += extension.c panelbinding.c
 
 man_seven_DATA = ibus-emoji.7


### PR DESCRIPTION
As that led to nondeterministic generated method names. This only seems to have a small effect on performance (~10s on a whole fresh build).

While I appreciate the ibus project doesn't consider such nondeterminisms as particularly problematic (#2272), having bitwise reproducible builds is increasingly desirable in Linux distributions, so hopefully you could consider applying this change nonetheless.