### PR TITLE
configure: Add warning to run `make -C tools maintainer-clean-generic`

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -931,6 +931,17 @@ AC_SUBST([GDBUS_CODEGEN], [`$PKG_CONFIG --variable gdbus_codegen gio-2.0`])
 
 OUTPUT_TAIL=''
 HAS_OUTPUT_TAIL=0
+AS_IF([test x"$enable_wayland" = x"no"],
+      [OUTPUT_TAIL="$OUTPUT_TAIL
+You invoked the \`configure\` script with disabled wayland option
+so you have to run
+\`make -C tools maintainer-clean-generic\` to regenerate C files with VALA
+before run \`make\`.
+"
+       HAS_OUTPUT_TAIL=1
+      ],
+      []
+)
 AS_IF([test x"$enable_ui" != x"no" &&
        test -f "$ac_confdir/ui/gtk3/application.c"
       ],


### PR DESCRIPTION
When users specify --disable-wayland option for configure, the behavior effects VALA files in tools and need to regenerate C files but many users don't know the steps so added a warning in the configure output to inform to run `make -C tools maintainer-clean-generic` of the users.

Fixes: https://github.com/ibus/ibus/commit/2bc23ed
BUG=https://github.com/ibus/ibus/issues/2836