### PR TITLE
ui/gtk3: GNOME Kiosk is also GNOME

### DIFF
--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -384,12 +384,14 @@ class Panel : IBus.PanelService {
     private static bool is_gnome() {
         unowned string? desktop =
             Environment.get_variable("XDG_CURRENT_DESKTOP");
-        if (desktop == "GNOME")
+        if (desktop != null && desktop.contains("GNOME"))
             return true;
         if (desktop == null || desktop == "(null)")
             desktop = Environment.get_variable("XDG_SESSION_DESKTOP");
-        if (desktop == "gnome" || desktop == "GNOME")
+        if (desktop != null &&
+            (desktop.contains("gnome") || desktop.contains("GNOME"))) {
             return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
The current implementation checks for the value of XDG_CURRENT_DESKTOP to be "GNOME" to determine whether GNOME is running.

GNOME Kiosk is another GNOME compositor, for which the value will be "GNOME_Kiosk:GNOME", hence causing the current check to fail to identify that as a GNOME session.

Fix the implementation to consider any string containing "GNOME" instead.