### PR TITLE
client/wayland: Close leaked keymap fd on early return

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -1115,7 +1115,10 @@ input_method_keyboard_keymap (void                      *data,
     IBusWaylandIMPrivate *priv;
     struct xkb_keymap *keymap;
 
-    g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+    if (!IBUS_IS_WAYLAND_IM (wlim)) {
+        close (fd);
+        g_return_if_reached ();
+    }
     priv = ibus_wayland_im_get_instance_private (wlim);
 
     /* wlroots/types/wlr_virtual_keyboard_v1.c:virtual_keyboard_keymap()


### PR DESCRIPTION
When input_method_keyboard_keymap() is called after the first keymap has already been set (priv->keymap, priv->state, and priv->state_system are all non-NULL), the function returns early without reaching create_system_xkb_keymap(), which is where close(fd) is called.

libwayland's wl_closure_marshal() dup()s the fd before sending it over the wire, so the caller's fd is not consumed by the preceding zwp_virtual_keyboard_v1_keymap() call.  Every activate/deactivate cycle triggers a new keymap event from the compositor, leaking one fd each time.  These accumulate as open fds to deleted /dev/shm/wlroots-* files.

Close the fd before the early return.