### PR TITLE
client/wayland: Close keymap fd on early return in input_method_keybo…

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -1133,8 +1133,10 @@ input_method_keyboard_keymap (void                      *data,
          */
         priv->seat->has_keymap = TRUE;
     }
-    if (priv->keymap && priv->state && priv->state_system)
+    if (priv->keymap && priv->state && priv->state_system) {
+        close (fd);
         return;
+    }
     keymap = create_system_xkb_keymap (priv->xkb_context, format, fd, size);
     if (keymap && !ibus_wayland_im_update_xkb_state (wlim, keymap))
         xkb_keymap_unref (keymap);


### PR DESCRIPTION
…ard_keymap

The previous commit closed the fd in the g_return_if_fail path but missed the early return when `priv->keymap`, `priv->state`, and `priv->state_system` are already set.  This is the path that actually leaks in normal operation--every activate/deactivate cycle after the first keymap triggers it.

BUG=https://github.com/ibus/ibus/pull/2861