### PR TITLE
client/wayland: Fix label at end of compound statement

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -1224,7 +1224,7 @@ ibus_wayland_im_post_key (IBusWaylandIM *wlim,
         case IBUS_ISO_Level5_Latch:
             filtered = TRUE;
             break;
-        default:
+        default:;
         }
 #endif
     }


### PR DESCRIPTION
Fix a typo in the 'default' label in switch() statement. NetBSD 10.1 uses GCC 10.5.0 which does not support the modern format yet.