### PR TITLE
client/wayland: Forward key instead of dropping it when ibuscontext i…

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -1361,8 +1361,22 @@ _process_key_event_sync (IBusWaylandIM       *wlim,
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     g_assert (event);
     priv = ibus_wayland_im_get_instance_private (wlim);
-    if (!priv->ibuscontext)
+    if (!priv->ibuscontext) {
+        retval = ibus_wayland_im_post_key (wlim,
+                                           event->key,
+                                           event->modifiers,
+                                           event->state,
+                                           0,
+                                           FALSE);
+        if (!retval) {
+            ibus_wayland_im_key (wlim,
+                                 event->key_serial,
+                                 event->time,
+                                 event->key,
+                                 event->state);
+        }
         return;
+    }
     retval = ibus_input_context_process_key_event (priv->ibuscontext,
                                                    event->sym,
                                                    event->key,


### PR DESCRIPTION
…s NULL in sync mode

_process_key_event_sync() silently dropped key events when ibuscontext was NULL.  Use the same fallback as input_method_keyboard_key(): try ibus_wayland_im_post_key(), then forward via ibus_wayland_im_key() if unhandled.