### PR TITLE
client/wayland: Handle zwp_input_method_v2 unavailable event

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -2394,13 +2394,21 @@ input_method_unavailable_v2 (void                       *data,
 {
     IBusWaylandIM *wlim = data;
     IBusWaylandIMPrivate *priv;
+    gchar *seat_name;
     struct zwp_input_method_union input_method;
 
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
-    g_return_if_fail (priv->seat);
-    g_warning ("Input method became unavailable on seat \"%s\".",
-               priv->seat->name);
+    g_assert (priv->seat);
+    seat_name = g_strdup (priv->seat->name);
+    if (!seat_name)
+        seat_name = g_strdup_printf ("wl_name:%u", priv->seat->wl_name);
+    g_warning ("%s becomes unavailable on seat \"%s\". "
+               "You might run another input method framework.",
+               priv->seat->input_method_v2 == input_method_v2 ? "Input method" :
+                       "Non-primary input method",
+               seat_name);
+    g_free (seat_name);
 
     if (priv->seat->active) {
         priv->seat->active = FALSE;

--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -2392,6 +2392,24 @@ static void
 input_method_unavailable_v2 (void                       *data,
                              struct zwp_input_method_v2 *input_method_v2)
 {
+    IBusWaylandIM *wlim = data;
+    IBusWaylandIMPrivate *priv;
+    struct zwp_input_method_union input_method;
+
+    g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+    priv = ibus_wayland_im_get_instance_private (wlim);
+    g_return_if_fail (priv->seat);
+    g_warning ("Input method became unavailable on seat \"%s\".",
+               priv->seat->name);
+
+    if (priv->seat->active) {
+        priv->seat->active = FALSE;
+        input_method.u.input_method_v2 = input_method_v2;
+        input_method_deactivate (data, &input_method, NULL);
+    }
+
+    zwp_input_method_v2_destroy (input_method_v2);
+    priv->seat->input_method_v2 = NULL;
 }
 
 


### PR DESCRIPTION
The unavailable handler was empty.  Per the protocol spec, the compositor sends this when another input method took over the seat or the seat was removed.  The input method object becomes inert and must be destroyed.

Deactivate the input method if active, destroy the protocol object, and log a warning so the user knows input stopped working on that seat.