### PR TITLE
client/wayland: Fix preedit cursor_end in set_preedit_string

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -673,7 +673,7 @@ _context_show_preedit_text_cb (IBusInputContext *context,
                 priv->seat->input_method_v2,
                 priv->preedit_text->text,
                 cursor,
-                strlen (priv->preedit_text->text));
+                cursor);
         zwp_input_method_v2_commit (priv->seat->input_method_v2,
                                     priv->im_serial);
         priv->hiding_preedit_text = FALSE;


### PR DESCRIPTION
cursor_end was set to strlen(text), making the cursor span from the cursor position to the end of the preedit string.  Per the zwp_input_method_v2 protocol, cursor_begin == cursor_end means a point cursor.  Pass cursor for both begin and end.