### PR TITLE
client/wayland: Fix typo "waylayd" -> "wayland" in Makefile.am

### DIFF
--- a/client/wayland/Makefile.am
+++ b/client/wayland/Makefile.am
@@ -184,8 +184,8 @@ MAINTAINERCLEANFILES += $(VAPIGEN_VAPIS)
 DISTCLEANFILES += $(VAPIGEN_VAPIS)
 $(VAPIGEN_VAPIS): $(INTROSPECTION_GIRS)
 ibus_wayland_im_1_0_vapi_DEPS = glib-2.0 gobject-2.0 gio-2.0 ibus-1.0
-ibus_waylayd_im_1_0_vapi_METADATADIRS = $(srcdir) $(top_srcdir)/bindings/vala
-#ibus_waylayd_im_1_0_vapi_VAPIDIRS = $(top_srcdir)/bindings/vala
+ibus_wayland_im_1_0_vapi_METADATADIRS = $(srcdir) $(top_srcdir)/bindings/vala
+#ibus_wayland_im_1_0_vapi_VAPIDIRS = $(top_srcdir)/bindings/vala
 ibus_wayland_im_1_0_vapi_FILES = \
     $(INTROSPECTION_GIRS) \
     $(srcdir)/ibus-wayland-im-custom.vala \


### PR DESCRIPTION
The misspelled variable name caused the METADATADIRS and VAPIDIRS settings to be silently ignored by automake.