### PR TITLE
ui/gtk3: Fix display wait timeout from ~5 years to 3 minutes

### DIFF
--- a/ui/gtk3/application.vala
+++ b/ui/gtk3/application.vala
@@ -25,7 +25,7 @@ const string IBUS_WAYLAND_VERSION="1.1";
 const ulong G_USEC_PER_SEC=1000000L;
 const ulong SLEEP_DIV_PER_SEC = 100L;
 const ulong MAX_DISPLAY_IDLE_TIME =
-        G_USEC_PER_SEC * SLEEP_DIV_PER_SEC * 60 * 3;
+        SLEEP_DIV_PER_SEC * 60 * 3;
 
 static string prgname;
 static IBus.Bus bus;


### PR DESCRIPTION
MAX_DISPLAY_IDLE_TIME included G_USEC_PER_SEC in the multiplication, making the iteration count 18 billion instead of the intended 18000. Each iteration sleeps 10ms, so the effective timeout was 5.7 years instead of the intended 3 minutes.

The sleep duration already uses G_USEC_PER_SEC / SLEEP_DIV_PER_SEC, so the iteration count should just be SLEEP_DIV_PER_SEC * 60 * 3.