### PR TITLE
ui/gtk3: Fix log timestamp losing microsecond precision

### DIFF
--- a/ui/gtk3/application.vala
+++ b/ui/gtk3/application.vala
@@ -216,9 +216,9 @@ class Application {
         if (m_user == null)
             m_user = "UNKNOW";
         GLib.DateTime now = new GLib.DateTime.now_local();
-        var msec = now.get_microsecond() / 1000;
-        m_log.printf("Start %02d:%02d:%02d:%06d\n",
-                     now.get_hour(), now.get_minute(), now.get_second(), msec);
+        m_log.printf("Start %02d:%02d:%02d.%06d\n",
+                     now.get_hour(), now.get_minute(), now.get_second(),
+                     now.get_microsecond());
         m_log.flush();
         return true;
     }


### PR DESCRIPTION
get_microsecond() was divided by 1000 (giving milliseconds) then formatted with %06d, producing misleading output like "000846". Use get_microsecond() directly with %06d, matching the C counterpart in ibuswaylandim.c.  Also use '.' separator instead of ':' to distinguish sub-second part from the time fields.