### PR TITLE
client/wayland: Copy keysym into async key event

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -1419,6 +1419,7 @@ _process_key_event_async (IBusWaylandIM       *wlim,
     async_event->key_serial = event->key_serial;
     async_event->time = event->time;
     async_event->key = event->key;
+    async_event->sym = event->sym;
     async_event->modifiers = event->modifiers & ~IBUS_RELEASE_MASK;
     async_event->state = event->state;
     async_event->wlim = wlim;


### PR DESCRIPTION
_process_key_event_async() did not copy event->sym into the async event struct.  The callback _process_key_event_done() then called ibus_wayland_im_post_key() with sym=0, so ISO_Level*_Latch keysyms were not filtered in async mode.