### PR TITLE
libibus: make an IBusText own an updated IBusAttrList reference

### DIFF
--- a/bindings/pygobject/Makefile.am
+++ b/bindings/pygobject/Makefile.am
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2012 Daiki Ueno <ueno@unixuser.org>
 # Copyright (c) 2014-2016 Peng Huang <shawn.p.huang@gmail.com>
-# Copyright (c) 2018-2019 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2018-2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
 # Copyright (c) 2012-2018 Red Hat, Inc.
 #
 # This library is free software; you can redistribute it and/or
@@ -27,37 +27,40 @@ NULL =
 if ENABLE_PYTHON2
 py2_compile = PYTHON=$(PYTHON2) $(SHELL) $(py_compile)
 overrides2dir = $(py2overridesdir)
-overrides2_DATA =				\
-	gi/overrides/IBus.py			\
-	$(NULL)
+overrides2_DATA =                               \
+    gi/overrides/IBus.py                        \
+    $(NULL)
 endif
 
 overridesdir = $(pyoverridesdir)
-overrides_PYTHON =				\
-	gi/overrides/IBus.py			\
-	$(NULL)
+overrides_PYTHON =                              \
+    gi/overrides/IBus.py                        \
+    $(NULL)
 
 TESTS =
 
 if ENABLE_TESTS
-TESTS += test-override-ibus.py
+TESTS += test-deserialize.py test-override-ibus.py
 endif
 
 # IBus.Keymap() accesses keymap files
 TESTS_ENVIRONMENT = \
-	PYTHONPATH=$(top_srcdir)/tests:$${PYTHONPATH:+:$$PYTHONPATH} \
-	LD_LIBRARY_PATH=$(top_builddir)/src/.libs:$$LD_LIBRARY_PATH \
-	GI_TYPELIB_PATH=$(top_builddir)/src:$$GI_TYPELIB_PATH \
-	IBUS_KEYMAP_PATH=$(top_srcdir)/data/keymaps \
-	$(NULL)
+    top_srcdir=$(top_srcdir) \
+    PYTHONPATH=$(abs_top_srcdir)/tests:$${PYTHONPATH:+:$$PYTHONPATH} \
+    PYTHONMALLOC=malloc \
+    LD_LIBRARY_PATH=$(abs_top_builddir)/src/.libs:$$LD_LIBRARY_PATH \
+    GI_TYPELIB_PATH=$(abs_top_builddir)/src:$$GI_TYPELIB_PATH \
+    IBUS_KEYMAP_PATH=$(abs_top_srcdir)/data/keymaps \
+    $(NULL)
 
-LOG_COMPILER = $(PYTHON) -B
+LOG_COMPILER = $(top_srcdir)/src/tests/runtest $(PYTHON)
 
-EXTRA_DIST =					\
-	gi/__init__.py				\
-	gi/overrides/__init__.py		\
-	test-override-ibus.py                   \
-	$(NULL)
+EXTRA_DIST =                                    \
+    gi/__init__.py                              \
+    gi/overrides/__init__.py                    \
+    test-deserialize.py                         \
+    test-override-ibus.py                       \
+    $(NULL)
 
 install-data-hook:
 	@$(NORMAL_INSTALL)

--- a/bindings/pygobject/meson.build
+++ b/bindings/pygobject/meson.build
@@ -4,6 +4,7 @@ pyoverrides_tests_env = {
   'PYTHONPATH': '@0@:@1@'.format(
           source_root / 'tests',
           python.get_variable('PYTHONPATH', '')),
+  'PYTHONMALLOC': 'malloc',
   'LD_LIBRARY_PATH': build_root / 'src',
   'GI_TYPELIB_PATH': build_root / 'src',
   'IBUS_KEYMAP_PATH': source_root / 'data' / 'keymaps',
@@ -11,6 +12,9 @@ pyoverrides_tests_env = {
 
 if get_option('tests')
   pyoverrides_tests = [
+    {
+      'name': 'test-deserialize',
+    },
     {
       'name': 'test-override-ibus',
     },

--- a/bindings/pygobject/test-deserialize.py
+++ b/bindings/pygobject/test-deserialize.py
@@ -1,0 +1,118 @@
+#!/usr/bin/python
+# ibus - The Input Bus
+#
+# Copyright © 2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+import sys
+import unittest
+from pathlib import Path
+
+# move the script path at the end, so the necessary modules in system
+# pygobject can be loaded first
+tests_builddir = Path(__file__).resolve().parent
+sys.path = [path for path in sys.path if Path(path) != tests_builddir]
+sys.path.append(str(tests_builddir))
+
+from gi import require_versions as gi_require_versions
+
+gi_require_versions({'IBus': '1.0', 'GLib':  '2.0', 'Gio': '2.0', })
+from gi.repository import IBus
+from gi.repository import GLib
+from gi.repository import Gio
+
+
+class TestOverride(unittest.TestCase):
+    __bus = None
+    __text = None
+    __attrs = None
+    __invocation = None
+
+    def setUp(self):
+        IBus.init()
+        self.__bus = IBus.Bus()
+
+    def update_preedit_text_cb(self,
+                               context,
+                               text,
+                               cursor,
+                               visible):
+        self.update_preedit_text_with_mode_cb(
+                context, text, cursor, visible, 0)
+
+    def update_preedit_text_with_mode_cb(self,
+                                         context,
+                                         text,
+                                         cursor,
+                                         visible,
+                                         mode):
+        self.__text = text
+        self.__attrs = self.__text.get_attributes()
+        print('# Got update-preedit-text-with-mode',
+              self.__text.get_text(), cursor, visible, mode)
+
+
+    def test_deserialized_input_context(self):
+        text = IBus.Text.new_from_string('test')
+        text.append_attribute(IBus.AttrType.HINT,
+                              IBus.AttrPreedit.WHOLE,
+                              0,
+                              text.get_length())
+        text_variant = text.serialize_object()
+        update_preedit_variant = GLib.Variant.new_tuple(
+            GLib.Variant.new_variant(text_variant),
+            GLib.Variant.new_uint32(0),
+            GLib.Variant.new_boolean(True),
+            GLib.Variant.new_uint32(0))
+        context = self.__bus.create_input_context('test')
+        context.connect('update-preedit-text-with-mode',
+                        self.update_preedit_text_with_mode_cb)
+        context.do_g_signal(context,
+                            'org.freedesktop.DBus',
+                            'UpdatePreeditTextWithMode',
+                            update_preedit_variant)
+        print('# Last', self.__attrs, self.__text.get_text())
+
+    def test_deserialized_panel(self):
+        text = IBus.Text.new_from_string('test')
+        text.append_attribute(IBus.AttrType.HINT,
+                              IBus.AttrPreedit.WHOLE,
+                              0,
+                              text.get_length())
+        text_variant = text.serialize_object()
+        update_preedit_variant = GLib.Variant.new_tuple(
+            GLib.Variant.new_variant(text_variant),
+            GLib.Variant.new_uint32(0),
+            GLib.Variant.new_boolean(True))
+        panel = IBus.PanelService.new(self.__bus.get_connection())
+        panel.connect('update-preedit-text',
+                      self.update_preedit_text_cb)
+        self.__invocation = Gio.DBusMethodInvocation()
+        panel.do_service_method_call(panel,
+                                     self.__bus.get_connection(),
+                                     'org.freedesktop.IBus.NullInvocation',
+                                     IBus.PATH_PANEL + '/DryTest',
+                                     IBus.INTERFACE_PANEL,
+                                     'UpdatePreeditText',
+                                     update_preedit_variant.ref(),
+                                     self.__invocation)
+        print('# Last', self.__attrs, self.__text.get_text())
+
+
+if __name__ == '__main__':
+    GLib.log_set_fatal_mask('GLib', GLib.LogLevelFlags.LEVEL_WARNING)
+    unittest.main()

--- a/bindings/pygobject/test-override-ibus.py
+++ b/bindings/pygobject/test-override-ibus.py
@@ -20,16 +20,15 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 # USA
 
-import unittest
-
-import os
 import sys
+import unittest
+from pathlib import Path
 
 # move the script path at the end, so the necessary modules in system
 # pygobject can be loaded first
-tests_builddir = os.path.abspath(os.path.dirname(__file__))
-sys.path = [path for path in sys.path if path != tests_builddir]
-sys.path.append(tests_builddir)
+tests_builddir = Path(__file__).resolve().parent
+sys.path = [path for path in sys.path if Path(path) != tests_builddir]
+sys.path.append(str(tests_builddir))
 
 import gi
 gi.require_versions({'GLib': '2.0', 'IBus': '1.0'})

--- a/src/ibusinputcontext.c
+++ b/src/ibusinputcontext.c
@@ -569,10 +569,8 @@ ibus_input_context_convert_text (IBusInputContext *context,
                        text->text, error->message);
             g_error_free (error);
         }
-        if (new_attrs) {
-            g_object_unref (text->attrs);
-            text->attrs = new_attrs;
-        }
+        if (new_attrs)
+            ibus_text_set_attributes (text, new_attrs);
         break;
     case IBUS_PREEDIT_FORMAT_HINT:
         new_attrs = ibus_attr_list_copy_format_to_hint (text->attrs, &error);
@@ -581,10 +579,8 @@ ibus_input_context_convert_text (IBusInputContext *context,
                        text->text, error->message);
             g_error_free (error);
         }
-        if (new_attrs) {
-            g_object_unref (text->attrs);
-            text->attrs = new_attrs;
-        }
+        if (new_attrs)
+            ibus_text_set_attributes (text, new_attrs);
         break;
     default:
         g_assert_not_reached ();

--- a/src/ibuspanelservice.c
+++ b/src/ibuspanelservice.c
@@ -1255,6 +1255,7 @@ ibus_panel_service_service_method_call (IBusService           *service,
         guint cursor = 0;
         gboolean visible = FALSE;
         IBusText *text;
+        gboolean is_dry_test;
 
         g_variant_get (parameters, "(vub)", &variant, &cursor, &visible);
         text = IBUS_TEXT (ibus_serializable_deserialize (variant));
@@ -1263,7 +1264,13 @@ ibus_panel_service_service_method_call (IBusService           *service,
 
         g_signal_emit (panel, panel_signals[UPDATE_PREEDIT_TEXT], 0, text, cursor, visible);
         _g_object_unref_if_floating (text);
-        g_dbus_method_invocation_return_value (invocation, NULL);
+        is_dry_test = !g_strcmp0 (object_path, IBUS_PATH_PANEL "/DryTest");
+        /* GDBusMethodInvocation does not provide instance methods for Python
+         * gobject-introspection binding so we cannot call
+         * g_dbus_method_invocation_return_value() and g_object_unref().
+         */
+        if (!is_dry_test)
+            g_dbus_method_invocation_return_value (invocation, NULL);
         return;
     }
 

--- a/src/ibuspanelservice.c
+++ b/src/ibuspanelservice.c
@@ -1203,10 +1203,8 @@ ibus_panel_convert_text (IBusPanelService *panel,
                        text->text, error->message);
             g_error_free (error);
         }
-        if (new_attrs) {
-            g_object_unref (text->attrs);
-            text->attrs = new_attrs;
-        }
+        if (new_attrs)
+            ibus_text_set_attributes (text, new_attrs);
         break;
     case IBUS_PREEDIT_FORMAT_HINT:
         new_attrs = ibus_attr_list_copy_format_to_hint (text->attrs, &error);
@@ -1215,10 +1213,8 @@ ibus_panel_convert_text (IBusPanelService *panel,
                        text->text, error->message);
             g_error_free (error);
         }
-        if (new_attrs) {
-            g_object_unref (text->attrs);
-            text->attrs = new_attrs;
-        }
+        if (new_attrs)
+            ibus_text_set_attributes (text, new_attrs);
         break;
     default:
         g_assert_not_reached ();

--- a/src/tests/runtest
+++ b/src/tests/runtest
@@ -37,11 +37,13 @@ ibus-engine-switch
 ibus-compose
 ibus-keypress
 test-stress
+test-deserialize.py
 test-override-ibus.py
 "
 IBUS_SCHEMA_FILE='org.freedesktop.ibus.gschema.xml'
 GTK_QUERY_MODULE=gtk-query-immodules-3.0-32
 MACHINE=`uname -m`
+PYTHON_TEST_ARGS='-B'
 
 if test x"$MACHINE" = xx86_64 ; then
     GTK_QUERY_MODULE=gtk-query-immodules-3.0-64
@@ -137,6 +139,12 @@ run_test_case()
     cd $tstdir
 
     if echo "$tst" | grep -q 'python' ; then
+        # Convert the relative path to the absolute path.
+        if echo "$tst" | grep -q "\./" ; then
+            tst=`realpath $tst`
+        elif ! echo "$tst" | grep -q "/" ; then
+            tst=`command -v $tst`
+        fi
         name=`func_basename "$1"`
     else
         name=`func_basename "$tst"`
@@ -247,10 +255,10 @@ run_test_case()
             shift
             if echo "$tst" | grep -q '^/' ; then
                 # absolute path for Meson
-                "$interpreter" "$tst" ${1+"$@"}
+                "$interpreter" $PYTHON_TEST_ARGS "$tst" ${1+"$@"}
             else
                 # relative path for autotools
-                "$interpreter" "../$tst" ${1+"$@"}
+                "$interpreter" $PYTHON_TEST_ARGS "../$tst" ${1+"$@"}
             fi
         else
             # absolute path for Meson


### PR DESCRIPTION
For all usages of IBusAttrList, the list is an owned reference within a
IBusText struct. `ibus_panel_convert_text()` and
`ibus_input_context_convert_text()` violate the invariant by assigning a
**floating** IBusAttrList reference to an IBusText without sinking it.

When GJS attempts to create a JS representation of an existing GObject,
it unconditionally sinks the incoming reference. For a non-floating
reference this up-refs the object.

For this floating IBusAttrLit, `g_object_ref_sink` converts it to a
strong reference in-place leaving ref-count at 1. At this point the
`IBusAttrList` is referenced by both the enclosing `IBusText` and the
newly created GJS wrapper. When one of them is ref-downed the object
is recycled, leaving the other reference dangling.

To fix this we just need to maintain the list as a non-floating ref.
We already have a `ibus_text_set_attributes()` that does the intended
ref sinking, so just use that instead of manually assigning pointers.

Fixes #2889.