### PR TITLE
client/x11: Call setlocale()

### DIFF
--- a/client/x11/main.c
+++ b/client/x11/main.c
@@ -1368,6 +1368,8 @@ main (int argc, char **argv)
     gdk_set_allowed_backends ("x11");
 #endif
 
+    /* gdk_init() does not call setlocale() */
+    setlocale (LC_ALL, "");
     gdk_init (&argc, &argv);
     XSetErrorHandler (_xerror_handler);
     XSetIOErrorHandler (_xerror_io_handler);


### PR DESCRIPTION
To enhance #2547, ibus-x11 replaces gtk_init() with gdk_init(). Seems gdk_init() does not call setlocale() internally and ibus-x11 causes some encoding errors when the multi-byte chars are converted to the text property of compound text.

Closes: #2896
Fixes: b185b21