### PR TITLE
ui/gtk3: avoid GLib spawn helper when starting ibus-daemon for Waylan…

### DIFF
--- a/ui/gtk3/application.vala
+++ b/ui/gtk3/application.vala
@@ -246,23 +246,45 @@ class Application {
         m_log.flush();
     }
 
-    private static bool run_ibus_daemon() {
-        string[] args = { "ibus-daemon" };
-        foreach (var arg in m_daemon_args.split(" "))
-            args += arg;
-        GLib.Pid child_pid = 0;
-        try {
-            GLib.Process.spawn_async (null, args, null,
-                                      GLib.SpawnFlags.DO_NOT_REAP_CHILD
-                                      | GLib.SpawnFlags.SEARCH_PATH,
-                                      null,
-                                      out child_pid);
-        } catch (GLib.SpawnError e) {
-            m_log.printf("ibus-daemon error: %s\n", e.message);
-            warning("%s\n", e.message);
-            return false;
+    private static GLib.Pid run_ibus_daemon() {
+        string[] daemon_args = {};
+        if (m_daemon_args != null && m_daemon_args != "") {
+            try {
+                GLib.Shell.parse_argv(m_daemon_args, out daemon_args);
+            } catch (GLib.ShellError e) {
+                var message = "Failed to parse daemon arguments: %s".printf(
+                        e.message);
+                m_log.printf("ibus-daemon error: %s\n", message);
+                warning("%s", message);
+                return 0;
+            }
         }
-        return true;
+
+        string[] args = { "ibus-daemon" };
+        foreach (var arg in daemon_args)
+            args += arg;
+        /*
+         * Launch ibus-daemon without GLib.Process.spawn_async() here because
+         * on some systems, g_spawn_async() uses a short-lived helper process,
+         * which reparents ibus-daemon to PID 1 before it reaches main().
+         * ibus-daemon then treats that as parent death and exits.
+         */
+        Posix.errno = 0;
+        GLib.Pid child_pid = Posix.fork();
+        if (child_pid < 0) {
+            var message = "fork failed: %s".printf(Posix.strerror(Posix.errno));
+            m_log.printf("ibus-daemon error: %s\n", message);
+            warning("%s", message);
+            return 0;
+        }
+        if (child_pid == 0) {
+            Posix.execvp("ibus-daemon", args);
+            var message = "execvp(ibus-daemon) failed: %s".printf(
+                    Posix.strerror(Posix.errno));
+            warning("%s", message);
+            Posix._exit(Posix.EXIT_FAILURE);
+        }
+        return child_pid;
     }
 
     private static void make_wayland_im() {
@@ -299,10 +321,20 @@ class Application {
         GLib.MainLoop? loop = null;
         if (!bus.is_connected() && m_exec_daemon) {
             m_bus_connected_id = bus.connected.connect((bus) => {
-                if (loop != null)
+                if (loop != null) {
                     loop.quit();
+                    loop = null;
+                }
             });
-            if (run_ibus_daemon()) {
+            var daemon_pid = run_ibus_daemon();
+            if (daemon_pid > 0) {
+                GLib.ChildWatch.add(daemon_pid, (pid, status) => {
+                    GLib.Process.close_pid(pid);
+                    if (loop != null) {
+                        loop.quit();
+                        loop = null;
+                    }
+                });
                 if (!bus.is_connected()) {
                     loop = new GLib.MainLoop();
                     loop.run();
@@ -326,8 +358,7 @@ class Application {
                     m_bus_connected_id = 0;
                 });
             }
-        }
-        if (bus.is_connected()) {
+        } else {
             m_wayland_im = new IBus.WaylandIM("bus", bus,
                                               "wl_display", wl_display,
                                               "log", m_log,


### PR DESCRIPTION
…d IM

When ibus-ui-gtk3 is started with --enable-wayland-im --exec-daemon, it starts ibus-daemon if no bus is already available.  This currently uses g_spawn_async() with G_SPAWN_DO_NOT_REAP_CHILD.

On systems where GLib implements g_spawn_async() through its spawn helper, the helper process can exit before ibus-daemon reaches main(). ibus-daemon then observes getppid() == 1 and exits through its existing parent-death check when it was not started with --daemonize.

The result is that ibus-daemon briefly creates the bus socket/address file, but exits before ibus-ui-gtk3 can complete the connection.  Clients then see the connection reset.

Avoid the GLib spawn helper in this path by using fork()/execv() directly.  This keeps ibus-daemon as a direct child of ibus-ui-gtk3, preserving the assumption made by ibus-daemon's parent check.  A child watch is still installed so the PID is reaped and the startup wait loop can terminate if ibus-daemon exits.

This only changes the Wayland IM auto-daemon path:
  ibus-ui-gtk3 --enable-wayland-im --exec-daemon

It does not change normal ibus-daemon startup, the XIM path, engine startup, or the panel behavior after the bus is connected.

tools/main.vala in the direct daemon startup path also does a similar thing: that code execs ibus-daemon directly.