### PR TITLE
client/wayland: Fix two SEGVs in surrounding-text hide-preedit-text signals

### DIFF
--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -325,7 +325,7 @@ ibus_wayland_im_commit_text (IBusWaylandIM *wlim,
                              const char    *str)
 {
     IBusWaylandIMPrivate *priv;
-    g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+    g_assert (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
     switch (priv->version) {
     case INPUT_METHOD_V1:
@@ -411,6 +411,14 @@ _context_commit_text_cb (IBusInputContext *context,
                          IBusText         *text,
                          IBusWaylandIM    *wlim)
 {
+    IBusWaylandIMPrivate *priv;
+
+    g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+    priv = ibus_wayland_im_get_instance_private (wlim);
+    /* FIXME: rhbz#2480408 If priv->ibuscontext exists,
+     * priv->context also should exists.
+     */
+    g_assert (priv->ibuscontext);
     ibus_wayland_im_commit_text (wlim, text->text);
 }
 
@@ -427,6 +435,8 @@ _context_forward_key_event_cb (IBusInputContext *context,
 
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
+    /* FIXME: rhbz#2480408 */
+    g_assert (priv->ibuscontext);
     if (modifiers & IBUS_RELEASE_MASK)
         state = WL_KEYBOARD_KEY_STATE_RELEASED;
     else
@@ -644,6 +654,8 @@ _context_show_preedit_text_cb (IBusInputContext *context,
     const char *commit = "";
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
+    /* FIXME: rhbz#2480408 */
+    g_assert (priv->ibuscontext);
     /* CURSOR is byte offset.  */
     cursor =
         g_utf8_offset_to_pointer (priv->preedit_text->text,
@@ -685,6 +697,8 @@ _context_hide_preedit_text_cb (IBusInputContext *context,
     IBusWaylandIMPrivate *priv;
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
+    /* FIXME: rhbz#2480408 */
+    g_assert (priv->ibuscontext);
     switch (priv->version) {
     case INPUT_METHOD_V1:
         zwp_input_method_context_v1_preedit_string (priv->context,
@@ -722,6 +736,8 @@ _context_update_preedit_text_cb (IBusInputContext *context,
     priv->preedit_cursor_pos = cursor_pos;
     priv->preedit_mode = mode;
 
+    /* FIXME: rhbz#2480408 */
+    g_assert (priv->ibuscontext);
     if (visible)
         _context_show_preedit_text_cb (context, wlim);
     else
@@ -746,6 +762,8 @@ _context_delete_surrounding_text_cb (IBusInputContext *context,
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
 
+    /* FIXME: rhbz#2480408 */
+    g_assert (priv->ibuscontext);
     if (!priv->surrounding_text)
         return;
 

--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -795,11 +795,21 @@ handle_surrounding_text (void                                  *data,
 #if ENABLE_SURROUNDING
     IBusWaylandIM *wlim = data;
     IBusWaylandIMPrivate *priv;
+    size_t len;
     IBusText *ibustext;
 
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
+    g_return_if_fail (text);
     priv = ibus_wayland_im_get_instance_private (wlim);
 
+    len = strlen (text);
+    if (G_UNLIKELY (len > G_MAXUINT32 || len < cursor || len < anchor)) {
+        /* Should not show the text as a security reason. */
+        g_warning ("Received a wrong surrounding text length %zu < cursor %u "
+                   "anchor %u",
+                   len, cursor, anchor);
+        return;
+    }
     ibustext = ibus_text_new_from_string (text);
 
     if (priv->surrounding_text)


### PR DESCRIPTION
KDE Plasma could send wrong cursor and anchor with surrounding_text() signal in `zwp_input_method_context_v1_listener`.
I'm not sure if it's caused by the compositor or IBus engines but ibus-wayland should ignore them.

The "hide-preedit-text" signal could cause a SEGV if the `zwp_input_method_context_v1` is NULL.
If the `zwp_input_method_context_v1` is deactivate, the `IBusIMContext` is should be cleared and the "hide-preedit-text" signal is also disconnected.
This issue might have a reason to receive the "hide-preedit-text" signal even though it's disconnected.
I added to check if priv->ibuscontext is NULL at the moment.