### PR TITLE
Separate system xkb_state from user one

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,7 @@ jobs:
             build: BUILD_MESON
           - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
+            test_config: '-Ddistro-tests=true'
             build: BUILD_MESON
             latest_xkb: KEEP_XKB_XML
           - container: ubuntu:resolute
@@ -57,6 +58,7 @@ jobs:
             build: BUILD_AUTOTOOL
           - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
+            test_config: '--enable-distro-tests'
             build: BUILD_AUTOTOOL
             latest_xkb: KEEP_XKB_XML
           - container: ubuntu:jammy

--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -96,8 +96,26 @@ struct _IBusWaylandSeat
     gboolean active;
     gboolean pending_activate;
     gboolean pending_deactivate;
-    gboolean has_keymap;
+    gboolean has_compositor_keymap;
 };
+
+typedef struct _IBusXkbKeymap
+{
+    struct xkb_keymap *keymap;
+    struct xkb_state *state;
+
+    xkb_mod_mask_t shift_mask;
+    xkb_mod_mask_t lock_mask;
+    xkb_mod_mask_t control_mask;
+    xkb_mod_mask_t mod1_mask;
+    xkb_mod_mask_t mod2_mask;
+    xkb_mod_mask_t mod3_mask;
+    xkb_mod_mask_t mod4_mask;
+    xkb_mod_mask_t mod5_mask;
+    xkb_mod_mask_t super_mask;
+    xkb_mod_mask_t hyper_mask;
+    xkb_mod_mask_t meta_mask;
+} IBusXkbKeymap;
 
 typedef struct _IBusWaylandIMPrivate IBusWaylandIMPrivate;
 struct _IBusWaylandIMPrivate
@@ -137,21 +155,8 @@ struct _IBusWaylandIMPrivate
 
     struct xkb_context *xkb_context;
 
-    struct xkb_keymap *keymap;
-    struct xkb_state *state;
-    struct xkb_state *state_system;
-
-    xkb_mod_mask_t shift_mask;
-    xkb_mod_mask_t lock_mask;
-    xkb_mod_mask_t control_mask;
-    xkb_mod_mask_t mod1_mask;
-    xkb_mod_mask_t mod2_mask;
-    xkb_mod_mask_t mod3_mask;
-    xkb_mod_mask_t mod4_mask;
-    xkb_mod_mask_t mod5_mask;
-    xkb_mod_mask_t super_mask;
-    xkb_mod_mask_t hyper_mask;
-    xkb_mod_mask_t meta_mask;
+    IBusXkbKeymap key_user;
+    IBusXkbKeymap key_sys;
 
     uint32_t im_serial;
     int32_t repeat_rate;
@@ -368,11 +373,11 @@ ibus_wayland_im_key (IBusWaylandIM *wlim,
     case INPUT_METHOD_V2:
         /* wlroots/types/wlr_virtual_keyboard_v1.c:virtual_keyboard_key()
          * returns "Cannot send a keypress before defining a keymap"
-         * if `has_keymap` is %FALSE.
+         * if `has_compositor_keymap` is %FALSE.
          */
         if (!priv->seat)
             break;
-        if (priv->seat->has_keymap) {
+        if (priv->seat->has_compositor_keymap) {
             zwp_virtual_keyboard_v1_key (priv->seat->virtual_keyboard,
                                          time, key, state);
         }
@@ -1059,16 +1064,21 @@ create_system_xkb_keymap (struct xkb_context *xkb_context,
 
 
 static gboolean
-ibus_wayland_im_update_xkb_state (IBusWaylandIM     *wlim,
-                                  struct xkb_keymap *keymap)
+ibus_xkb_keymap_update_with_keymap (IBusXkbKeymap     *ibus_keymap,
+                                    struct xkb_keymap *keymap)
 {
-    IBusWaylandIMPrivate *priv;
     struct xkb_state *state;
 
-    g_return_val_if_fail (IBUS_IS_WAYLAND_IM (wlim), FALSE);
-    priv = ibus_wayland_im_get_instance_private (wlim);
+    g_return_val_if_fail (ibus_keymap, FALSE);
     g_return_val_if_fail (keymap, FALSE);
     g_return_val_if_fail ((state = xkb_state_new (keymap)), FALSE);
+
+    if (ibus_keymap->state)
+        xkb_state_unref (ibus_keymap->state);
+    if (ibus_keymap->keymap)
+        xkb_keymap_unref (ibus_keymap->keymap);
+    ibus_keymap->keymap = keymap;
+    ibus_keymap->state = state;
 
     /* xkb_map_mod_get_index() can return any xkb_mod_index_t value, including
      * values wider than xkb_mod_mask_t can represent.  Shifting by those values
@@ -1078,25 +1088,19 @@ ibus_wayland_im_update_xkb_state (IBusWaylandIM     *wlim,
     ({ xkb_mod_index_t idx = xkb_map_mod_get_index (keymap, name); \
        (idx < sizeof (xkb_mod_mask_t) * CHAR_BIT) \
                ? ((xkb_mod_mask_t) 1 << idx) : 0; })
-    priv->shift_mask   = _WL_MOD_MASK (keymap, "Shift");
-    priv->lock_mask    = _WL_MOD_MASK (keymap, "Lock");
-    priv->control_mask = _WL_MOD_MASK (keymap, "Control");
-    priv->mod1_mask    = _WL_MOD_MASK (keymap, "Mod1");
-    priv->mod2_mask    = _WL_MOD_MASK (keymap, "Mod2");
-    priv->mod3_mask    = _WL_MOD_MASK (keymap, "Mod3");
-    priv->mod4_mask    = _WL_MOD_MASK (keymap, "Mod4");
-    priv->mod5_mask    = _WL_MOD_MASK (keymap, "Mod5");
-    priv->super_mask   = _WL_MOD_MASK (keymap, "Super");
-    priv->hyper_mask   = _WL_MOD_MASK (keymap, "Hyper");
-    priv->meta_mask    = _WL_MOD_MASK (keymap, "Meta");
+    ibus_keymap->shift_mask   = _WL_MOD_MASK (keymap, "Shift");
+    ibus_keymap->lock_mask    = _WL_MOD_MASK (keymap, "Lock");
+    ibus_keymap->control_mask = _WL_MOD_MASK (keymap, "Control");
+    ibus_keymap->mod1_mask    = _WL_MOD_MASK (keymap, "Mod1");
+    ibus_keymap->mod2_mask    = _WL_MOD_MASK (keymap, "Mod2");
+    ibus_keymap->mod3_mask    = _WL_MOD_MASK (keymap, "Mod3");
+    ibus_keymap->mod4_mask    = _WL_MOD_MASK (keymap, "Mod4");
+    ibus_keymap->mod5_mask    = _WL_MOD_MASK (keymap, "Mod5");
+    ibus_keymap->super_mask   = _WL_MOD_MASK (keymap, "Super");
+    ibus_keymap->hyper_mask   = _WL_MOD_MASK (keymap, "Hyper");
+    ibus_keymap->meta_mask    = _WL_MOD_MASK (keymap, "Meta");
 #undef _WL_MOD_MASK
 
-    if (priv->state)
-        xkb_state_unref (priv->state);
-    if (priv->keymap)
-        xkb_keymap_unref (priv->keymap);
-    priv->keymap = keymap;
-    priv->state = state;
     return TRUE;
 }
 
@@ -1117,8 +1121,10 @@ _bus_global_engine_changed_cb (IBusBus       *bus,
     g_assert (desc);
     g_assert (!g_strcmp0 (ibus_engine_desc_get_name (desc), engine_name));
     keymap = create_user_xkb_keymap (priv->xkb_context, desc);
-    if (keymap && !ibus_wayland_im_update_xkb_state (wlim, keymap))
+    if (keymap && !ibus_xkb_keymap_update_with_keymap (&priv->key_user,
+                                                       keymap)) {
         xkb_keymap_unref (keymap);
+    }
     g_object_unref (desc);
 }
 
@@ -1148,19 +1154,37 @@ input_method_keyboard_keymap (void                      *data,
         zwp_virtual_keyboard_v1_keymap (priv->seat->virtual_keyboard,
                                         format, fd, size);
         /* wlroots/types/wlr_virtual_keyboard_v1.c:virtual_keyboard_keymap()
-         * sets %TRUE to `has_keymap`.
+         * sets %TRUE to `has_compositor_keymap`.
          */
-        priv->seat->has_keymap = TRUE;
+        priv->seat->has_compositor_keymap = TRUE;
     }
-    if (priv->keymap && priv->state && priv->state_system) {
+    if (priv->key_user.keymap && priv->key_user.state && priv->key_sys.state) {
         close (fd);
         return;
     }
     keymap = create_system_xkb_keymap (priv->xkb_context, format, fd, size);
-    if (keymap && !ibus_wayland_im_update_xkb_state (wlim, keymap))
+    if (keymap &&
+        !ibus_xkb_keymap_update_with_keymap (&priv->key_sys,
+                                             xkb_keymap_ref (keymap))) {
         xkb_keymap_unref (keymap);
-    if (priv->state)
-        priv->state_system = xkb_state_ref (priv->state);
+        g_clear_pointer (&keymap, xkb_keymap_unref);
+    }
+    if (keymap && !priv->key_user.state &&
+        !ibus_xkb_keymap_update_with_keymap (&priv->key_user,
+                                             xkb_keymap_ref (keymap))) {
+        xkb_keymap_unref (keymap);
+        g_clear_pointer (&keymap, xkb_keymap_unref);
+    }
+    if (keymap)
+        xkb_keymap_unref (keymap);
+    if (priv->verbose) {
+        fprintf (priv->log, "System keymap format:%u fd:%d size:%u "
+                            "keymap:%s state:%s\n",
+                 format, fd, size,
+                 keymap ? "TRUE" : "FALSE",
+                 priv->key_sys.state ? "TRUE" : "FALSE");
+        fflush (priv->log);
+    }
 }
 
 
@@ -1207,6 +1231,7 @@ ibus_wayland_im_post_key (IBusWaylandIM *wlim,
                           gboolean       filtered)
 {
     IBusWaylandIMPrivate *priv;
+    IBusXkbKeymap *active_key;
     uint32_t code = key + 8;
     uint32_t ch;
 
@@ -1226,7 +1251,8 @@ ibus_wayland_im_post_key (IBusWaylandIM *wlim,
     default:
         g_assert_not_reached ();
     }
-    if (!priv->state)
+    active_key = &priv->key_user;
+    if (!active_key->state)
         return FALSE;
     if (!filtered) {
 #if 0
@@ -1248,7 +1274,7 @@ ibus_wayland_im_post_key (IBusWaylandIM *wlim,
 #endif
     }
     if (!filtered && (state != WL_KEYBOARD_KEY_STATE_RELEASED)) {
-        ch = xkb_state_key_get_utf32 (priv->state, code);
+        ch = xkb_state_key_get_utf32 (active_key->state, code);
         if (!(modifiers & IBUS_MODIFIER_MASK & ~IBUS_SHIFT_MASK) &&
             ch && ch != '\n' && ch != '\b' && ch != '\r' && ch != '\t' &&
             ch != '\033' && ch != '\x7f') {
@@ -1258,7 +1284,7 @@ ibus_wayland_im_post_key (IBusWaylandIM *wlim,
             filtered = TRUE;
         }
     }
-    xkb_state_update_key (priv->state, code,
+    xkb_state_update_key (active_key->state, code,
                           (state == WL_KEYBOARD_KEY_STATE_RELEASED)
                           ? XKB_KEY_UP : XKB_KEY_DOWN);
     return filtered;
@@ -1681,8 +1707,10 @@ input_method_keyboard_key (void                      *data,
 
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
-    if (!priv->state)
+    if (!priv->key_user.state) {
+        ibus_wayland_im_key (wlim, key_serial, time, key, state);
         return;
+    }
 
     if (!priv->ibuscontext) {
         gboolean retval = ibus_wayland_im_post_key (wlim,
@@ -1703,10 +1731,10 @@ input_method_keyboard_key (void                      *data,
     code = key + 8;
     event.sym = 0;
     /* xkb_key_get_syms() does not return the capital syms with Shift key. */
-    if (priv->state_system)
-        event.sym = xkb_state_key_get_one_sym (priv->state_system, code);
+    if (priv->key_sys.state)
+        event.sym = xkb_state_key_get_one_sym (priv->key_sys.state, code);
     if (event.sym != IBUS_KEY_Multi_key)
-        event.sym = xkb_state_key_get_one_sym (priv->state, code);
+        event.sym = xkb_state_key_get_one_sym (priv->key_user.state, code);
     event.modifiers = priv->modifiers;
     if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
         event.modifiers |= IBUS_RELEASE_MASK;
@@ -1735,38 +1763,57 @@ input_method_keyboard_modifiers (void                      *data,
 {
     IBusWaylandIM *wlim = data;
     IBusWaylandIMPrivate *priv;
-    xkb_mod_mask_t mask;
+    IBusXkbKeymap *active_key;
+    xkb_mod_mask_t mask = 0;
 
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
-    xkb_state_update_mask (priv->state, mods_depressed,
-                           mods_latched, mods_locked, 0, 0, group);
-    mask = xkb_state_serialize_mods (priv->state,
-                                     XKB_STATE_DEPRESSED |
-                                     XKB_STATE_LATCHED);
+    active_key = &priv->key_user;
+    if (priv->key_user.state) {
+        xkb_state_update_mask (priv->key_user.state, mods_depressed,
+                               mods_latched, mods_locked, 0, 0, group);
+    }
+    /* Pressing XKB group key likes Alt_R with grp:toggle calls
+     * input_method_keyboard_modifiers() with the updated `group`
+     * and need to update priv->key_sys.state to switch the XKB group
+     * in the system keymap.
+     *
+     * XKB group key can switch `group` but clicking the keyboard icon
+     * of KDE does not change `group` at present. Maybe a bug in the
+     * KDE Wayland compositor.
+     */
+    if (priv->key_sys.state) {
+        xkb_state_update_mask (priv->key_sys.state, mods_depressed,
+                               mods_latched, mods_locked, 0, 0, group);
+    }
+    if (active_key->state) {
+        mask = xkb_state_serialize_mods (active_key->state,
+                                         XKB_STATE_DEPRESSED |
+                                         XKB_STATE_LATCHED);
+    }
 
     priv->modifiers = 0;
-    if (mask & priv->shift_mask)
+    if (mask & active_key->shift_mask)
         priv->modifiers |= IBUS_SHIFT_MASK;
-    if (mask & priv->lock_mask)
+    if (mask & active_key->lock_mask)
         priv->modifiers |= IBUS_LOCK_MASK;
-    if (mask & priv->control_mask)
+    if (mask & active_key->control_mask)
         priv->modifiers |= IBUS_CONTROL_MASK;
-    if (mask & priv->mod1_mask)
+    if (mask & active_key->mod1_mask)
         priv->modifiers |= IBUS_MOD1_MASK;
-    if (mask & priv->mod2_mask)
+    if (mask & active_key->mod2_mask)
         priv->modifiers |= IBUS_MOD2_MASK;
-    if (mask & priv->mod3_mask)
+    if (mask & active_key->mod3_mask)
         priv->modifiers |= IBUS_MOD3_MASK;
-    if (mask & priv->mod4_mask)
+    if (mask & active_key->mod4_mask)
         priv->modifiers |= IBUS_MOD4_MASK;
-    if (mask & priv->mod5_mask)
+    if (mask & active_key->mod5_mask)
         priv->modifiers |= IBUS_MOD5_MASK;
-    if (mask & priv->super_mask)
+    if (mask & active_key->super_mask)
         priv->modifiers |= IBUS_SUPER_MASK;
-    if (mask & priv->hyper_mask)
+    if (mask & active_key->hyper_mask)
         priv->modifiers |= IBUS_HYPER_MASK;
-    if (mask & priv->meta_mask)
+    if (mask & active_key->meta_mask)
         priv->modifiers |= IBUS_META_MASK;
 
     switch (priv->version) {
@@ -1778,11 +1825,11 @@ input_method_keyboard_modifiers (void                      *data,
     case INPUT_METHOD_V2:
         /* wlroots/types/wlr_virtual_keyboard_v1.c:virtual_keyboard_modifiers()
          * returns "Cannot send a modifier state before defining a keymap"
-         * if `has_keymap` is %FALSE.
+         * if `has_compositor_keymap` is %FALSE.
          */
         if (!priv->seat)
             break;
-        if (priv->seat->has_keymap) {
+        if (priv->seat->has_compositor_keymap) {
             zwp_virtual_keyboard_v1_modifiers (priv->seat->virtual_keyboard,
                                                mods_depressed, mods_latched,
                                                mods_locked, group);
@@ -2067,7 +2114,7 @@ input_method_activate (void                               *data,
         /* Regenerating `virtual_keyboard` causes `size` = 0 in
          * input_method_keyboard_keymap() with focus changes in Sway session.
          */
-        priv->seat->has_keymap = FALSE;
+        priv->seat->has_compositor_keymap = FALSE;
         priv->seat->keyboard_v2 = zwp_input_method_v2_grab_keyboard (
                 input_method->u.input_method_v2);
         zwp_input_method_keyboard_grab_v2_add_listener (
@@ -2773,8 +2820,10 @@ ibus_wayland_im_constructor (GType                  type,
     desc = ibus_bus_get_global_engine (priv->ibusbus);
     if (desc)
         keymap = create_user_xkb_keymap (priv->xkb_context, desc);
-    if (keymap && !ibus_wayland_im_update_xkb_state (wlim, keymap))
-        xkb_keymap_unref (keymap);
+    if (keymap && !ibus_xkb_keymap_update_with_keymap (&priv->key_user,
+                                                       keymap)) {
+        g_clear_pointer (&keymap, xkb_keymap_unref);
+    }
     ibus_bus_set_watch_ibus_signal (priv->ibusbus, TRUE);
     g_signal_connect (priv->ibusbus, "global-engine-changed",
                       G_CALLBACK (_bus_global_engine_changed_cb),
@@ -2850,9 +2899,10 @@ ibus_wayland_im_destroy (IBusObject *object)
         g_clear_pointer (&priv->input_method_manager_v2,
                          zwp_input_method_manager_v2_destroy);
     }
-    g_clear_pointer (&priv->state_system, xkb_state_unref);
-    g_clear_pointer (&priv->state, xkb_state_unref);
-    g_clear_pointer (&priv->keymap, xkb_keymap_unref);
+    g_clear_pointer (&priv->key_user.state, xkb_state_unref);
+    g_clear_pointer (&priv->key_sys.state, xkb_state_unref);
+    g_clear_pointer (&priv->key_user.keymap, xkb_keymap_unref);
+    g_clear_pointer (&priv->key_sys.keymap, xkb_keymap_unref);
     g_clear_pointer (&priv->xkb_context, xkb_context_unref);
     if (priv->log) {
         fclose (priv->log);

--- a/client/wayland/ibuswaylandim.c
+++ b/client/wayland/ibuswaylandim.c
@@ -45,7 +45,8 @@ enum {
     PROP_BUS,
     PROP_DISPLAY,
     PROP_LOG,
-    PROP_VERBOSE
+    PROP_VERBOSE,
+    PROP_USE_SYS_KEYMAP
 };
 
 enum {
@@ -122,6 +123,7 @@ struct _IBusWaylandIMPrivate
 {
     FILE *log;
     gboolean verbose;
+    gboolean use_sys_keymap;
     struct wl_display *display;
     IMProtocolVersion version;
 
@@ -1120,6 +1122,10 @@ _bus_global_engine_changed_cb (IBusBus       *bus,
     desc = ibus_bus_get_global_engine (bus);
     g_assert (desc);
     g_assert (!g_strcmp0 (ibus_engine_desc_get_name (desc), engine_name));
+    /* Always update priv->key_user even if priv->use_sys_keymap is %FALSE
+     * so that ibus_wayland_im_set_property() switches %PROP_USE_SYS_KEYMAP
+     * immediately without checking the Gsettings.
+     */
     keymap = create_user_xkb_keymap (priv->xkb_context, desc);
     if (keymap && !ibus_xkb_keymap_update_with_keymap (&priv->key_user,
                                                        keymap)) {
@@ -1251,7 +1257,10 @@ ibus_wayland_im_post_key (IBusWaylandIM *wlim,
     default:
         g_assert_not_reached ();
     }
-    active_key = &priv->key_user;
+    if (priv->use_sys_keymap)
+        active_key = &priv->key_sys;
+    else
+        active_key = &priv->key_user;
     if (!active_key->state)
         return FALSE;
     if (!filtered) {
@@ -1273,7 +1282,17 @@ ibus_wayland_im_post_key (IBusWaylandIM *wlim,
         }
 #endif
     }
-    if (!filtered && (state != WL_KEYBOARD_KEY_STATE_RELEASED)) {
+    /* In case `use_sys_keymap` is %TRUE, IBus does not commit ASCII chars
+     * but forwards the key events to the focused application here.
+     * Because some applications treat the printable keys as control keys,
+     * E.g. game apps "hjkl" use the cursor move like VI mode.
+     * Unfortunately the Wayland input-method protocol does not provide
+     * the fallback logic after apps handle the key events like GTK3/2
+     * IM modules. But The input-method always should handles key events
+     * prior to apps.
+     */
+    if (!filtered && (state != WL_KEYBOARD_KEY_STATE_RELEASED) &&
+        !priv->use_sys_keymap) {
         ch = xkb_state_key_get_utf32 (active_key->state, code);
         if (!(modifiers & IBUS_MODIFIER_MASK & ~IBUS_SHIFT_MASK) &&
             ch && ch != '\n' && ch != '\b' && ch != '\r' && ch != '\t' &&
@@ -1707,7 +1726,7 @@ input_method_keyboard_key (void                      *data,
 
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
-    if (!priv->key_user.state) {
+    if (!priv->key_user.state && !priv->key_sys.state) {
         ibus_wayland_im_key (wlim, key_serial, time, key, state);
         return;
     }
@@ -1733,7 +1752,7 @@ input_method_keyboard_key (void                      *data,
     /* xkb_key_get_syms() does not return the capital syms with Shift key. */
     if (priv->key_sys.state)
         event.sym = xkb_state_key_get_one_sym (priv->key_sys.state, code);
-    if (event.sym != IBUS_KEY_Multi_key)
+    if (event.sym != IBUS_KEY_Multi_key && priv->key_user.state)
         event.sym = xkb_state_key_get_one_sym (priv->key_user.state, code);
     event.modifiers = priv->modifiers;
     if (state == WL_KEYBOARD_KEY_STATE_RELEASED)
@@ -1768,7 +1787,10 @@ input_method_keyboard_modifiers (void                      *data,
 
     g_return_if_fail (IBUS_IS_WAYLAND_IM (wlim));
     priv = ibus_wayland_im_get_instance_private (wlim);
-    active_key = &priv->key_user;
+    if (priv->use_sys_keymap)
+        active_key = &priv->key_sys;
+    else
+        active_key = &priv->key_user;
     if (priv->key_user.state) {
         xkb_state_update_mask (priv->key_user.state, mods_depressed,
                                mods_latched, mods_locked, 0, 0, group);
@@ -2682,6 +2704,21 @@ ibus_wayland_im_class_init (IBusWaylandIMClass *class)
                         FALSE,
                         G_PARAM_READWRITE | G_PARAM_CONSTRUCT_ONLY));
 
+    /**
+     * IBusWaylandIM:use-system-keymap:
+     *
+     * Use system keymap.
+     * %TRUE if the session keymap is used forcibly instead of keymaps of the
+     * IBus XKB engines, otherwise %FALSE.
+     */
+    g_object_class_install_property (gobject_class,
+                    PROP_USE_SYS_KEYMAP,
+                    g_param_spec_boolean ("use-system-keymap",
+                        "use system keymap",
+                        "Use system keymap",
+                        FALSE,
+                        G_PARAM_READWRITE));
+
     /* install signals */
     /* this module can call ibus_input_context_focus_in() and the focus-in
      * signal can reach the IBus panel and this also can call
@@ -2949,6 +2986,9 @@ ibus_wayland_im_set_property (IBusWaylandIM *wlim,
         g_assert (!priv->verbose);
         priv->verbose = g_value_get_boolean (value);
         break;
+    case PROP_USE_SYS_KEYMAP:
+        priv->use_sys_keymap = g_value_get_boolean (value);
+        break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (wlim, prop_id, pspec);
     }
@@ -2977,6 +3017,9 @@ ibus_wayland_im_get_property (IBusWaylandIM *wlim,
         break;
     case PROP_VERBOSE:
         g_value_set_boolean (value, priv->verbose);
+        break;
+    case PROP_USE_SYS_KEYMAP:
+        g_value_set_boolean (value, priv->use_sys_keymap);
         break;
     default:
         G_OBJECT_WARN_INVALID_PROPERTY_ID (wlim, prop_id, pspec);

--- a/configure.ac
+++ b/configure.ac
@@ -793,6 +793,18 @@ PKG_CHECK_MODULES(XFIXES,
     [have_xfixes="no (libXfixes version is lower than 6)"]
 )
 
+# --enable-distro-tests
+AC_ARG_ENABLE(distro-tests,
+    AS_HELP_STRING([--enable-distro-tests],
+                   [Enable to test distro files]),
+    [enable_distro_tests=$enableval],
+    [enable_distro_tests=no]
+)
+AM_CONDITIONAL([ENABLE_DISTRO_TESTS], [test x"$enable_distro_tests" = x"yes"])
+if test x"$enable_distro_tests" = x"no"; then
+    enable_distro_tests="no (disabled, use --enable-distro-tests to enable)"
+fi
+
 # --enable-install-tests
 AC_ARG_ENABLE(install-tests,
     AS_HELP_STRING([--enable-install-tests],
@@ -1069,6 +1081,7 @@ Build options:
   XFixes client disconnect      $have_xfixes
   Install systemd service       $enable_systemd
   Run test cases                $enable_tests
+  Distro tests                  $enable_distro_tests
   Install tests                 $enable_install_tests
 ])
 AS_IF([test $HAS_OUTPUT_TAIL -eq 1],

--- a/engine/Makefile.am
+++ b/engine/Makefile.am
@@ -4,7 +4,7 @@
 #
 # Copyright (c) 2010-2016, Google Inc. All rights reserved.
 # Copyright (c) 2007-2016 Peng Huang <shawn.p.huang@gmail.com>
-# Copyright (c) 2013-2025 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2013-2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -57,10 +57,17 @@ AM_VALAFLAGS = \
     --target-glib="$(VALA_TARGET_GLIB_VERSION)" \
     $(NULL)
 
+TESTS_ENVIRONMENT = \
+    lib_srcdir=$(srcdir)/../src \
+    $(NULL)
+
 TESTS =
 
+if ENABLE_DISTRO_TESTS
+TESTS += test-dead.py
 if ENABLE_PYGNOME_DESKTOP
 TESTS += test-gnome.py
+endif
 endif
 
 libexec_PROGRAMS = \
@@ -99,6 +106,7 @@ EXTRA_DIST = \
     gensimple.py \
     iso639converter.py \
     simple.xml.in \
+    test-dead.py \
     test-gnome.py \
     $(NULL)
 

--- a/engine/meson.build
+++ b/engine/meson.build
@@ -41,17 +41,21 @@ simple_xml = custom_target('simple.xml',
   install_dir: pkgdatadir / 'component',
 )
 
-if get_option('tests')
-  pyoverrides_tests = [
-    {
-      'name': 'test-gnome',
-    },
+distro_tests_env = {
+  'lib_srcdir': source_root / 'src',
+}
+
+if get_option('tests') and get_option('distro-tests')
+  distro_tests = [
+    { 'name': 'test-dead', },
+    { 'name': 'test-gnome', },
   ]
 
-  foreach _test : pyoverrides_tests
+  foreach _test : distro_tests
     timeout = _test.get('timeout', 30)
     test(_test['name'], files([python.full_path()])[0],
       args: [ meson.current_source_dir() / '@0@.py'.format(_test['name']) ],
+      env: environment(distro_tests_env),
       suite: 'engine',
       timeout: timeout,
     )

--- a/engine/test-dead.py
+++ b/engine/test-dead.py
@@ -1,0 +1,141 @@
+#!/usr/bin/python3
+# vim:set fileencoding=utf-8 et sts=4 sw=4:
+#
+# ibus - Intelligent Input Bus for Linux / Unix OS
+#
+# Copyright © 2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library. If not, see <http://www.gnu.org/licenses/>.
+
+# Check src/ibusinternal.h:IS_DEAD_KEY()
+
+import os, sys
+from pathlib import Path
+
+class TestDeadKey:
+    __srcdir = None
+    __prgname = None
+    __is_dead_key_file = Path('ibusinternal.h')
+    __dead_keys_file  = Path('ibuskeysyms.h')
+    __max_dead_line = None
+    __max_dead_key  = None
+    __max_dead_val = 0
+    __min_dead_line = None
+    __min_dead_key  = None
+    __min_dead_val = 0xffff
+
+    @classmethod
+    def parse_args(cls):
+        arg0 = Path(sys.argv[0])
+        cls.__srcdir = arg0.parent.parent
+        cls.__prgname = arg0.name
+        lib_srcdir = os.getenv('lib_srcdir')
+        if len(sys.argv) > 1:
+            cls.__srcdir = Path(sys.argv[1])
+        elif lib_srcdir is not None:
+            cls.__srcdir = Path(lib_srcdir)
+        if str(cls.__srcdir) == '':
+            cls.__srcdir = Path('.')
+
+    def tests(self):
+        print('TAP version 14')
+        print('1..1')
+        dead_keys_path = self.__srcdir / self.__dead_keys_file
+        if not dead_keys_path.exists():
+            print(f'fail Not found {str(dead_keys_path)}', file=sys.stderr)
+            sys.exit(1)
+        is_dead_key_path = self.__srcdir / self.__is_dead_key_file
+        if not is_dead_key_path.exists():
+            print(f'fail Not found {str(is_dead_key_path)}', file=sys.stderr)
+            sys.exit(1)
+        self.read_dead_keys_file(dead_keys_path)
+        if self.read_is_dead_key_file(is_dead_key_path):
+            print(f'ok 1 /{self.__prgname}')
+        else:
+            sys.exit(1)
+
+    def read_dead_keys_file(self, dead_keys_path):
+        with dead_keys_path.open() as f:
+            for line in f:
+                elements = line.split()
+                if len(elements) < 3:
+                    continue
+                if elements[0] != '#define':
+                    continue
+                if not elements[1].startswith('IBUS_KEY_dead'):
+                    continue
+                try:
+                    val = int(elements[2], 0)
+                except ValueError:
+                    continue
+                if self.__max_dead_val < val:
+                    self.__max_dead_val = val
+                    self.__max_dead_line = line
+                    self.__max_dead_key = elements[1]
+                if self.__min_dead_val > val:
+                    self.__min_dead_val = val
+                    self.__min_dead_line = line
+                    self.__min_dead_key = elements[1]
+        if self.__min_dead_val >= self.__max_dead_val:
+            print(f'fail {self.__min_dead_line} < {self.__max_dead_line}',
+                  file=sys.stderr)
+            sys.exit(1)
+
+    def read_is_dead_key_file(self, is_dead_key_path):
+        import re
+        has_definition = False
+        min_key = ''
+        max_key = ''
+        with is_dead_key_path.open() as f:
+            for line in f:
+                # Avoid to detect 'IS_DEAD_KEY' and 'IBUS_KEY_dead_*' in the
+                # comment lines and assume '#define' and 'IS_DEAD_KEY'
+                # are always in the same line.
+                if not has_definition:
+                    elements = line.split()
+                    if len(elements) < 2:
+                        continue
+                    if elements[0] != '#define':
+                        continue
+                    if elements[1].startswith('IS_DEAD_KEY'):
+                        has_definition = True
+                # ((k) >= IBUS_KEY_dead_min && (k) <= IBUS_KEY_dead_max)
+                else:
+                    matches = re.findall(r'IBUS_KEY_dead_\w+', line)
+                    if len(matches) >= 2:
+                        min_key = matches[0]
+                        max_key = matches[1]
+                        break
+        is_failed = False
+        print(f'# min: {min_key} < max: {max_key}')
+        if self.__min_dead_key != min_key:
+            print('fail min of IS_DEAD_KEY() is %s but min in %s is %s' % \
+                  (min_key, str(self.__dead_keys_file), self.__min_dead_key),
+                  file=sys.stderr)
+            is_failed = True
+        if self.__max_dead_key != max_key:
+            print('fail max of IS_DEAD_KEY() is %s but max in %s is %s' % \
+                  (max_key, str(self.__dead_keys_file), self.__max_dead_key),
+                  file=sys.stderr)
+            is_failed = True
+        return not is_failed
+
+
+def main():
+    TestDeadKey.parse_args()
+    obj = TestDeadKey()
+    obj.tests()
+    sys.exit(0)
+
+main()

--- a/meson.options
+++ b/meson.options
@@ -3,6 +3,11 @@ option('tests',
   value: true,
   description: 'Build tests',
 )
+option('distro-tests',
+  type: 'boolean',
+  value: false,
+  description: 'Enable to test distro files',
+)
 option('tests-exclude-suites',
   type: 'string',
   value: '',

--- a/src/ibuscomposetable.c
+++ b/src/ibuscomposetable.c
@@ -36,6 +36,7 @@
 #include "ibustypes.h"
 
 #include "ibusenginesimpleprivate.h"
+#include "ibusinternal.h"
 
 
 #define IBUS_COMPOSE_TABLE_MAGIC "IBusComposeTable"
@@ -101,7 +102,7 @@ parse_compose_value (IBusComposeData  *compose_data,
                      const char       *val,
                      const char       *line)
 {
-    char *head, *end, *p;
+    const char *head, *end, *p;
     char *ustr = NULL;
     gunichar *uchars = NULL, *up;
     GError *error = NULL;
@@ -165,7 +166,10 @@ parse_compose_value (IBusComposeData  *compose_data,
 
     g_free (ustr);
     g_free (uchars);
-    compose_data->comment = g_strdup (g_strstrip (end + 1));
+    /* The argument of g_strstrip() is `char *` but not `const char *` and
+     * the API uses memmove() internally to keep the allocated pointer.
+     */
+    compose_data->comment = g_strstrip (g_strdup (end + 1));
 
     return TRUE;
 
@@ -1991,7 +1995,7 @@ ibus_compose_table_check (const IBusComposeTableEx *table,
     int row_stride = table->max_seq_len + 2;
     const guint16 *data_first;
     int n_seqs;
-    guint16 *seq;
+    const guint16 *seq, *prev_seq;
 
     if (compose_finish)
         *compose_finish = FALSE;
@@ -2020,8 +2024,6 @@ ibus_compose_table_check (const IBusComposeTableEx *table,
     if (seq == NULL)
         return FALSE;
 
-    guint16 *prev_seq;
-
     /* Back up to the first sequence that matches to make sure
      * we find the exact match if their is one.
      */
@@ -2034,7 +2036,7 @@ ibus_compose_table_check (const IBusComposeTableEx *table,
 
     /* complete sequence */
     if (n_compose == table->max_seq_len || seq[n_compose] == 0) {
-        guint16 *next_seq;
+        const guint16 *next_seq;
         gunichar value = 0;
         int num = 0;
         int index = 0;

--- a/src/ibusenginesimple.c
+++ b/src/ibusenginesimple.c
@@ -28,11 +28,13 @@
 #include "ibuscomposetable.h"
 #include "ibusemoji.h"
 #include "ibusenginesimple.h"
-#include "ibusenginesimpleprivate.h"
 
 #include "ibuskeys.h"
 #include "ibuskeysyms.h"
 #include "ibusutil.h"
+
+#include "ibusenginesimpleprivate.h"
+#include "ibusinternal.h"
 
 #include <memory.h>
 #include <stdlib.h>

--- a/src/ibusenginesimpleprivate.h
+++ b/src/ibusenginesimpleprivate.h
@@ -35,12 +35,6 @@ G_BEGIN_DECLS
  */
 #define IBUS_COMPOSE_ERROR (ibus_compose_error_quark ())
 
-/* Checks if a keysym is a dead key. Dead key keysym values are defined in
- * ibuskeysyms.h and the first is GDK_KEY_dead_grave.
- */
-#define IS_DEAD_KEY(k) \
-      ((k) >= IBUS_KEY_dead_grave && (k) <= IBUS_KEY_dead_greek)
-
 
 struct _IBusComposeTablePrivate
 {
@@ -57,8 +51,10 @@ struct _IBusComposeTablePrivate
  * Since: 1.5.33
  * Stability: Unstable
  */
+G_GNUC_INTERNAL
 GQuark   ibus_compose_error_quark   (void);
 guint    ibus_compose_key_flag      (guint                       key);
+G_GNUC_INTERNAL
 gboolean ibus_check_algorithmically (const guint                *compose_buffer,
                                      int                         n_compose,
                                      gunichar                   *output);
@@ -67,11 +63,13 @@ GVariant *
                                     (IBusComposeTableEx
                                                                 *compose_table,
                                      gboolean                   reverse_endian);
+G_GNUC_INTERNAL
 IBusComposeTableEx *
          ibus_compose_table_deserialize
                                     (const char                 *contents,
                                      gsize                       length,
                                      guint16                    *saved_version);
+G_GNUC_INTERNAL
 gboolean ibus_compose_table_check   (const IBusComposeTableEx   *table,
                                      guint                      *compose_buffer,
                                      int                         n_compose,
@@ -79,6 +77,7 @@ gboolean ibus_compose_table_check   (const IBusComposeTableEx   *table,
                                      gboolean                   *compose_match,
                                      GString                    *output,
                                      gboolean                    is_32bit);
+G_GNUC_INTERNAL
 gunichar ibus_keysym_to_unicode     (guint                       keysym,
                                      gboolean                    combining,
                                      gboolean                   *need_space);
@@ -88,6 +87,7 @@ gunichar ibus_keysym_to_unicode     (guint                       keysym,
  * Since: 1.5.33
  * Stability: Unstable
  */
+G_GNUC_INTERNAL
 gunichar ibus_keysym_to_unicode_with_layout
                                     (guint                       keysym,
                                      gboolean                    combining,

--- a/src/ibusinternal.h
+++ b/src/ibusinternal.h
@@ -62,5 +62,14 @@
 G_GNUC_INTERNAL void
 ibus_g_variant_get_child_string (GVariant *variant, gsize index, char **str);
 
-#endif
+#ifdef IBUS_KEY_dead_grave
+#ifdef IBUS_KEY_dead_longsolidusoverlay
+/* Checks if a keysym is a dead key. Dead key keysym values are defined in
+ * ibuskeysyms.h and the first is GDK_KEY_dead_grave.
+ */
+#define IS_DEAD_KEY(k) \
+      ((k) >= IBUS_KEY_dead_grave && (k) <= IBUS_KEY_dead_longsolidusoverlay)
+#endif /* IBUS_KEY_dead_longsolidusoverlay */
+#endif /* IBUS_KEY_dead_grave */
 
+#endif

--- a/ui/gtk3/application.vala
+++ b/ui/gtk3/application.vala
@@ -39,6 +39,7 @@ class Application {
 #if USE_GDK_WAYLAND
     private static ulong m_bus_connected_id;
     private static ulong m_realize_surface_id;
+    private static ulong m_use_system_keymap_id;
     private static ulong m_ibus_focus_in_id;
     private static ulong m_ibus_focus_out_id;
     private static string m_user;
@@ -115,6 +116,8 @@ class Application {
         if (m_wayland_im != null) {
             m_realize_surface_id = m_panel.realize_surface.connect(
                     (w, s) => this.set_wayland_surface(s));
+            m_use_system_keymap_id = m_panel.use_system_keymap.connect(
+                    (w, b) => m_wayland_im.use_system_keymap = b);
             m_ibus_focus_in_id = m_wayland_im.ibus_focus_in.connect(
                     (w, o) => m_panel.set_wayland_object_path(o));
             m_ibus_focus_out_id = m_wayland_im.ibus_focus_out.connect(
@@ -145,6 +148,10 @@ class Application {
         if (m_realize_surface_id != 0) {
             GLib.SignalHandler.disconnect(m_panel, m_realize_surface_id);
             m_realize_surface_id = 0;
+        }
+        if (m_use_system_keymap_id != 0) {
+            GLib.SignalHandler.disconnect(m_panel, m_use_system_keymap_id);
+            m_use_system_keymap_id = 0;
         }
         if (m_ibus_focus_in_id != 0) {
             GLib.SignalHandler.disconnect(m_wayland_im, m_ibus_focus_in_id);

--- a/ui/gtk3/panel.vala
+++ b/ui/gtk3/panel.vala
@@ -104,9 +104,7 @@ class Panel : IBus.PanelService {
 #if USE_GDK_WAYLAND
     private string? m_wayland_object_path;
     public signal void realize_surface(void *surface);
-    public signal void update_shortcut_keys(
-            IBus.ProcessKeyEventData[] data,
-            BindingCommon.KeyEventFuncType ftype);
+    public signal void use_system_keymap(bool use_sys_keymap);
 #endif
 
     public Panel(IBus.Bus bus,
@@ -747,6 +745,9 @@ class Panel : IBus.PanelService {
     private void set_use_system_keyboard_layout() {
         m_use_system_keyboard_layout =
                 m_settings_general.get_boolean("use-system-keyboard-layout");
+#if USE_GDK_WAYLAND
+        use_system_keymap(m_use_system_keyboard_layout);
+#endif
     }
 
     private void set_embed_preedit_text() {


### PR DESCRIPTION
Forked some patches from #2869 since some PRs need the system keymap and separate the issues against the latch key issues.