### PR TITLE
Enhance build flags and fix some build errors

### DIFF
--- a/.github/hooks/applypatch-msg
+++ b/.github/hooks/applypatch-msg
@@ -4,7 +4,7 @@
 #
 # ibus - The Input Bus
 #
-# Copyright (c) 2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -35,10 +35,6 @@ test -x "$IBUS_HOOK" &&
     exit 1
 }
 
-check_if_hook_is_latest "$IBUS_HOOK" || exit 1
-cat "$1" | check_signed_off_by || exit 1
-cat "$1" | check_commit_id_from_stdin || exit 1
-cat "$1" | check_tmp_version || exit 1
-spell_checking << EOF_ENVS_MAIN
-`cat "$1"`
-EOF_ENVS_MAIN
+check_if_gh_is_active || exit 1
+insert_pr_id $@
+exit 0

--- a/.github/hooks/ibus-commit-common
+++ b/.github/hooks/ibus-commit-common
@@ -149,7 +149,9 @@ spell_checking()
         # Spell check
         (look $word > /dev/null) && continue || :
         # Source file path check
-        (grep -q "$word" <(find . -depth)) && continue || :
+        # `grep -q` causes find to stderr 'standard output': Broken pipe
+        # so the stderr is redirected to /dev/null
+        find . -depth 2>/dev/null | grep -qs "$word" && continue || :
         # System file path check
         test -f "$word" && continue || :
         # Variable check

--- a/.github/hooks/ibus-commit-common
+++ b/.github/hooks/ibus-commit-common
@@ -4,7 +4,7 @@
 #
 # ibus - The Input Bus
 #
-# Copyright (c) 2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2023-2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -21,7 +21,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
 # USA
 
-# You can copy this file to .git/hooks/commit-msg with the file permission
+# You can copy this file to .git/hooks/ with the file permission
 # '0755'.
 # This script is useful not to commit invalid commit IDs every time and
 # leave a temporary version(1.5.00) in source files when a release is
@@ -46,7 +46,7 @@ TOOLS="autoconf|aclocal|libtool|keymap|keysym|keycode|pointerkey|gzip|xev"
 TOOLS="$TOOLS|d-bus|emojier"
 ACRONYMS="i18n|l10n|m17n|a11y"
 
-echo -e "\033[37;1mIBus commit-msg\033[0m"
+echo -e "\033[1;30;47mIBus commit-msg\033[0m"
 
 
 check_if_hook_is_latest()
@@ -66,6 +66,19 @@ check_if_hook_is_latest()
     diff "$GITHUB_DIR/$IBUS_FILE" "$GIT_DIR/hooks/$IBUS_FILE" || {
         echo >&2 ""
         echo >&2 "ERROR: $1 is older than $GITHUB_DIR/$IBUS_FILE"
+        exit 1
+    }
+}
+
+check_if_gh_is_active()
+{
+    which gh > /dev/null 2>&1 || {
+        echo >&2 "Please install gh command from https://github.com/cli/cli"
+        exit 1
+    }
+
+    gh auth status > /dev/null || {
+        echo >&2 "You are not logged into any GitHub hosts. To log in, run: gh auth login"
         exit 1
     }
 }
@@ -143,7 +156,8 @@ spell_checking()
         (echo "$word" | grep -q "$BSH$DLL") && continue || :
         MISSPELLINGS="$MISSPELLINGS $word"
     done << EOF_ENVS_INTERNAL
-    `cat </dev/stdin | grep -v "^#" | grep -vi "^fixes: " |\
+    `cat </dev/stdin | grep -v "^#" | grep -vi "^closes: " |\
+      grep -vi "^fixes:" | grep -vi "^part-of: " |\
       tr "$DELIM" " " | tr " 	" "\n" |\
      grep -Ev "http:|https:|ftp:|rdp:|nfs:|smb:|file:" | grep -Eiv "$EX_APIS" |\
      grep -Eiv "$DISTROS" | grep -Eiv "$PLATFORMS" | grep -Eiv "$TOOLS" |\
@@ -162,5 +176,52 @@ EOF_ENVS_INTERNAL
     MISSPELLINGS="$(expr "$MISSPELLINGS" : ' \(.*\)')"
     test x"$MISSPELLINGS" = x"" || {
         echo "WARNING: Possible spelling errors \"$MISSPELLINGS\""
+    }
+}
+
+insert_pr_id()
+{
+    grep -qis "^part-of: " "$1" && return || :
+    # Exclude merge command
+    test "x$2" != "x" && return || :
+    GIT_BRANCH=$(git branch --show-current)
+    {
+        test "x$GIT_BRANCH" = "xmain" || test "x$GIT_BRANCH" = "xmaster"
+    } && {
+        echo >&2 "Need to create another branch to insert Part-of instead of $GIT_BRANCH"
+        return
+    } || :
+    {
+        ! MAX_ISSUE_ID=$(gh issue list --state all --limit 1 --json number --jq '.[0].number' --repo $REPO) || test "x$MAX_ISSUE_ID" = x
+    } && {
+        echo >&2 "Failed to fetch the latest issue ID for $REPO"
+        return
+    } || :
+    {
+        ! MAX_PR_ID=$(gh pr list --state all --limit 1 --json number --jq '.[0].number' --repo $REPO) || test "x$MAX_PR_ID" = x
+    } && {
+        echo >&2 "Failed to fetch the latest pull request ID for $REPO"
+        return
+    } || :
+    test $MAX_ISSUE_ID -ge $MAX_PR_ID && MAX_ID=$MAX_ISSUE_ID || MAX_ID=$MAX_PR_ID
+    MAX_ID=$(($MAX_ID + 1))
+    inserted_lines="Part-of: #$MAX_ID"
+    grep -qis "^Closes: " "$1" || echo "$0" | grep -qis 'applypatch-msg' || {
+        inserted_lines="${inserted_lines}\nCloses: #"
+    }
+    # If you use GIT_EDITOR=vi, you have to run ":cq" to cancel `git commit`
+    # because `git/hook/prepare-commit-msg` already changed the edit buffer so
+    # you cannot use ":q!" to cancel the command.
+    VIM_COMMENT="# Please enter the commit message for your changes."
+    grep -qis "^$VIM_COMMENT" "$1" && {
+        sed -i "/^$VIM_COMMENT/i \
+$inserted_lines
+" "$1"
+        echo -e \
+"\033[33mType ':cq' to cancel 'git commit' instead of ':q!' in case of GIT_EDITOR=vi\033[0m"
+    } || {
+        # Add a null line to separate the subject and description in `git am`.
+        echo "" >> "$1"
+        echo "$inserted_lines" >> "$1"
     }
 }

--- a/.github/hooks/ibus-commit-config
+++ b/.github/hooks/ibus-commit-config
@@ -1,0 +1,3 @@
+# You can customize variables to uncomment and modify following lines
+#REPO="ibus/ibus"
+#GITHUB_DIR="/home/foo/GIT/ibus/.github/hooks"

--- a/.github/hooks/prepare-commit-msg
+++ b/.github/hooks/prepare-commit-msg
@@ -4,7 +4,7 @@
 #
 # ibus - The Input Bus
 #
-# Copyright (c) 2023 Takao Fujiwara <takao.fujiwara1@gmail.com>
+# Copyright (c) 2026 Takao Fujiwara <takao.fujiwara1@gmail.com>
 #
 # This library is free software; you can redistribute it and/or
 # modify it under the terms of the GNU Lesser General Public
@@ -35,10 +35,5 @@ test -x "$IBUS_HOOK" &&
     exit 1
 }
 
-check_if_hook_is_latest "$IBUS_HOOK" || exit 1
-cat "$1" | check_signed_off_by || exit 1
-cat "$1" | check_commit_id_from_stdin || exit 1
-cat "$1" | check_tmp_version || exit 1
-spell_checking << EOF_ENVS_MAIN
-`cat "$1"`
-EOF_ENVS_MAIN
+check_if_gh_is_active || exit 1
+insert_pr_id $@

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: ["fedora:43", "fedora:44", "ubuntu:jammy", "ubuntu:resolute"]
+        container: ["fedora:44", "fedora:45", "ubuntu:jammy", "ubuntu:resolute"]
     steps:
       - name: Check container sha tags
         run: |
@@ -26,18 +26,18 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - container: fedora:43
+          - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
             build: BUILD_MESON
-          - container: fedora:43
+          - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
             test_config: '-Dwayland=disabled'
             build: BUILD_MESON
-          - container: fedora:43
+          - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
             test_config: '-Dappindicator=false'
             build: BUILD_MESON
-          - container: fedora:44
+          - container: fedora:45
             ucd_dir: /usr/share/unicode/ucd
             test_config: '-Ddistro-tests=true'
             build: BUILD_MESON
@@ -45,18 +45,18 @@ jobs:
           - container: ubuntu:resolute
             ucd_dir: /usr/share/unicode
             build: BUILD_MESON
-          - container: fedora:43
+          - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
             build: BUILD_AUTOTOOL
-          - container: fedora:43
+          - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
             test_config: '--disable-wayland'
             build: BUILD_AUTOTOOL
-          - container: fedora:43
+          - container: fedora:44
             ucd_dir: /usr/share/unicode/ucd
             test_config: '--disable-appindicator'
             build: BUILD_AUTOTOOL
-          - container: fedora:44
+          - container: fedora:45
             ucd_dir: /usr/share/unicode/ucd
             test_config: '--enable-distro-tests'
             build: BUILD_AUTOTOOL

--- a/bindings/pygobject/test-deserialize.py
+++ b/bindings/pygobject/test-deserialize.py
@@ -38,7 +38,9 @@ from gi.repository import Gio
 
 class TestOverride(unittest.TestCase):
     __bus = None
+    __context = None
     __text = None
+    __panel = None
     __attrs = None
     __invocation = None
 
@@ -66,51 +68,66 @@ class TestOverride(unittest.TestCase):
               self.__text.get_text(), cursor, visible, mode)
 
 
-    def test_deserialized_input_context(self):
+    def __test_deserialized_input_context_real(self, case):
         text = IBus.Text.new_from_string('test')
-        text.append_attribute(IBus.AttrType.HINT,
-                              IBus.AttrPreedit.WHOLE,
-                              0,
-                              text.get_length())
+        if case == 1:
+            text.append_attribute(IBus.AttrType.HINT,
+                                  IBus.AttrPreedit.WHOLE,
+                                  0,
+                                  text.get_length())
         text_variant = text.serialize_object()
         update_preedit_variant = GLib.Variant.new_tuple(
             GLib.Variant.new_variant(text_variant),
             GLib.Variant.new_uint32(0),
             GLib.Variant.new_boolean(True),
             GLib.Variant.new_uint32(0))
-        context = self.__bus.create_input_context('test')
-        context.connect('update-preedit-text-with-mode',
-                        self.update_preedit_text_with_mode_cb)
-        context.do_g_signal(context,
-                            'org.freedesktop.DBus',
-                            'UpdatePreeditTextWithMode',
-                            update_preedit_variant)
+        self.__context.do_g_signal(self.__context,
+                                   'org.freedesktop.DBus',
+                                   'UpdatePreeditTextWithMode',
+                                   update_preedit_variant)
         print('# Last', self.__attrs, self.__text.get_text())
+        self.__attrs = None
+        self.__text = None
 
-    def test_deserialized_panel(self):
+    def __test_deserialized_panel_real(self, case):
         text = IBus.Text.new_from_string('test')
-        text.append_attribute(IBus.AttrType.HINT,
-                              IBus.AttrPreedit.WHOLE,
-                              0,
-                              text.get_length())
+        if case == 1:
+            text.append_attribute(IBus.AttrType.HINT,
+                                  IBus.AttrPreedit.WHOLE,
+                                  0,
+                                  text.get_length())
         text_variant = text.serialize_object()
         update_preedit_variant = GLib.Variant.new_tuple(
             GLib.Variant.new_variant(text_variant),
             GLib.Variant.new_uint32(0),
             GLib.Variant.new_boolean(True))
-        panel = IBus.PanelService.new(self.__bus.get_connection())
-        panel.connect('update-preedit-text',
-                      self.update_preedit_text_cb)
-        self.__invocation = Gio.DBusMethodInvocation()
-        panel.do_service_method_call(panel,
-                                     self.__bus.get_connection(),
-                                     'org.freedesktop.IBus.NullInvocation',
-                                     IBus.PATH_PANEL + '/DryTest',
-                                     IBus.INTERFACE_PANEL,
-                                     'UpdatePreeditText',
-                                     update_preedit_variant.ref(),
-                                     self.__invocation)
+        self.__panel.do_service_method_call(
+                self.__panel,
+                self.__bus.get_connection(),
+                'org.freedesktop.IBus.NullInvocation',
+                IBus.PATH_PANEL + '/DryTest',
+                IBus.INTERFACE_PANEL,
+                'UpdatePreeditText',
+                update_preedit_variant.ref(),
+                self.__invocation)
         print('# Last', self.__attrs, self.__text.get_text())
+        self.__attrs = None
+        self.__text = None
+
+    def test_deserialized_input_context(self):
+        self.__context = self.__bus.create_input_context('test')
+        self.__context.connect('update-preedit-text-with-mode',
+                               self.update_preedit_text_with_mode_cb)
+        self.__test_deserialized_input_context_real(0)
+        self.__test_deserialized_input_context_real(1)
+
+    def test_deserialized_panel(self):
+        self.__panel = IBus.PanelService.new(self.__bus.get_connection())
+        self.__panel.connect('update-preedit-text',
+                             self.update_preedit_text_cb)
+        self.__invocation = Gio.DBusMethodInvocation()
+        self.__test_deserialized_panel_real(0)
+        self.__test_deserialized_panel_real(1)
 
 
 if __name__ == '__main__':

--- a/bus/ibusimpl.c
+++ b/bus/ibusimpl.c
@@ -637,7 +637,7 @@ bus_ibus_impl_init (BusIBusImpl *ibus)
     ibus->fake_context = bus_input_context_new (NULL, "fake");
     g_object_ref_sink (ibus->fake_context);
     bus_dbus_impl_register_object (BUS_DEFAULT_DBUS,
-                                   (IBusService *) ibus->fake_context);
+                                   (IBusService *)ibus->fake_context);
     bus_input_context_set_capabilities (ibus->fake_context,
                                         IBUS_CAP_PREEDIT_TEXT |
                                         IBUS_CAP_FOCUS |
@@ -733,8 +733,15 @@ bus_ibus_impl_destroy (BusIBusImpl *ibus)
     g_clear_pointer (&ibus->global_engine_name, g_free);
     g_clear_pointer (&ibus->global_previous_engine_name, g_free);
 
-    if (ibus->fake_context)
+    if (ibus->fake_context) {
+        bus_dbus_impl_unregister_object (BUS_DEFAULT_DBUS,
+                                         (IBusService *)ibus->fake_context);
+        g_signal_handlers_disconnect_by_func (
+                ibus->fake_context,
+                G_CALLBACK (_context_engine_changed_cb),
+                ibus);
         g_clear_pointer (&ibus->fake_context, g_object_unref);
+    }
 
     bus_ibus_impl_registry_destroy (ibus);
 

--- a/client/gtk2/ibusim.c
+++ b/client/gtk2/ibusim.c
@@ -20,7 +20,14 @@
  * USA
  */
 
+#define GDK_DISABLE_DEPRECATION_WARNINGS
+/* GTK2 has no GDK_DISABLE_DEPRECATION_WARNINGS */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
+#undef GDK_DISABLE_DEPRECATION_WARNINGS
+
 #include <gtk/gtkimmodule.h>
 #include <ibus.h>
 #include "ibusimcontext.h"

--- a/client/gtk2/ibusimcontext.c
+++ b/client/gtk2/ibusimcontext.c
@@ -26,9 +26,15 @@
 #endif
 
 #include <string.h>
+#define GDK_DISABLE_DEPRECATION_WARNINGS
+/* GTK2 has no GDK_DISABLE_DEPRECATION_WARNINGS */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
 #include <gdk/gdk.h>
 #include <gdk/gdkkeysyms.h>
+#undef GDK_DISABLE_DEPRECATION_WARNINGS
 #include <ibus.h>
 #include <ibusattrlistprivate.h>
 #include "ibusimcontext.h"
@@ -1695,13 +1701,15 @@ static gboolean
 _set_cursor_location_internal (IBusIMContext *ibusimcontext)
 {
     GdkRectangle area;
-    GdkDisplay *display = NULL;
 #if GTK_CHECK_VERSION (3, 98, 4)
     GtkWidget *root;
     GtkNative *native;
     graphene_point_t p;
     int tx = 0, ty = 0;
     double nx = 0., ny = 0.;
+    GdkDisplay *display = NULL;
+#elif defined(GDK_WINDOWING_WAYLAND)
+    GdkDisplay *display = NULL;
 #endif
 
     if(ibusimcontext->client_window == NULL ||

--- a/client/gtk2/iconwidget.c
+++ b/client/gtk2/iconwidget.c
@@ -21,7 +21,11 @@
  */
 
 #define GDK_DISABLE_DEPRECATION_WARNINGS
+/* GTK2 has no GDK_DISABLE_DEPRECATION_WARNINGS */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #include <gtk/gtk.h>
+#pragma GCC diagnostic pop
 #undef GDK_DISABLE_DEPRECATION_WARNINGS
 
 #include "iconwidget.h"

--- a/docs/reference/ibus/meson.build
+++ b/docs/reference/ibus/meson.build
@@ -30,6 +30,8 @@ gnome.gtkdoc('ibus',
   ignore_headers: ibus_docs_ignore_headers,
   dependencies: ibus_dep,
   gobject_typesfile: 'ibus.types',
+  # In case of get_option('warning_level') = 1 and c_args = '-Werror=format-security'
+  c_args: get_option('warning_level') != '0' ? [ '-Wall' ] : [],
   scan_args: [
     '--rebuild-sections',
   ],

--- a/meson.build
+++ b/meson.build
@@ -100,7 +100,7 @@ endif
 # Dependencies
 #-------------------------------------------------
 # Also used for Vala's --target-glib, so no micro version.
-min_glib_version = '2.46'
+min_glib_version = '2.60'
 glib_dep = dependency('glib-2.0', version: '>=' + min_glib_version)
 gobject_dep = dependency('gobject-2.0', version: '>=' + min_glib_version)
 gio_dep = dependency('gio-2.0', version: '>=' + min_glib_version)
@@ -180,15 +180,15 @@ xkbcommon_dep = dependency('xkbcommon', required: false)
 x11_dep = dependency('x11', required: get_option('xim'))
 enable_xim = x11_dep.found()
 if enable_xim
-  have_xkblib = cc.has_header('X11/XKBlib.h')
+  enable_xkblib = cc.has_header('X11/XKBlib.h')
 
   xfixes_dep = dependency('xfixes', required: false)
-  have_xfixes = xfixes_dep.found()
+  enable_xfixes = xfixes_dep.found()
 
   x11_prefix = x11_dep.get_variable(pkgconfig: 'prefix')
 else
-  have_xkblib = false
-  have_xfixes = false
+  enable_xkblib = false
+  enable_xfixes = false
   x11_prefix = get_option('prefix')
 endif
 
@@ -336,24 +336,27 @@ conf.set_quoted('NO_SNOOPER_APPS', ','.join(get_option('no-snooper-apps')))
 conf.set_quoted('IBUS_SOCKET_DIR', ibus_socket_dir)
 conf.set_quoted('UI_WAYLAND_DESKTOP',
                 'org.freedesktop.IBus.Panel.Wayland.Gtk3.desktop')
+
 conf.set('ENABLE_NLS', enable_nls)
 conf.set('HAVE_DAEMON', cc.has_function('daemon'))
 conf.set('HAVE_GETGRGID_R', cc.has_header_symbol('grp.h', 'getgrgid_r'))
 conf.set('HAVE_GETTEXT', enable_gnu_gettext)
 conf.set('HAVE_LOCALE_H', cc.has_header_symbol('locale.h', 'LC_ALL'))
+conf.set('HAVE_PRODUCT_BUILD', buildtype == 'release')
 conf.set('HAVE_SYS_PRCTL_H', cc.has_header_symbol('sys/prctl.h', 'prctl'))
 conf.set('HAVE_JSON_GLIB1', json_glib_dep.found())
-conf.set('HAVE_X11_XKBLIB_H', have_xkblib)
-conf.set('HAVE_XFIXES', have_xfixes)
+conf.set('HAVE_X11_XKBLIB_H', enable_xkblib)
+conf.set('HAVE_XFIXES', enable_xfixes)
 conf.set('HAVE_XIM', enable_xim)
+# glib 2.65 was generated after 2020
 conf.set('GLIB2_EMBED_ERRNO_H', glib_dep.found() and
          glib_dep.version().version_compare('>= 2.65.0'))
 conf.set('DCONF_0_13_4', dconf_dep.found() and
                          dconf_dep.version().version_compare('>= 0.13.4'))
+
+# Apply 'TRUE' but not true because the 'ENABLE_SURROUNDING' is used
+# for not "#ifdef" only but also "#if"
 conf.set('ENABLE_SURROUNDING', 'TRUE')
-if buildtype == 'release'
-    conf.set('HAVE_PRODUCT_BUILD', 'TRUE')
-endif
 
 configure_file(
   input: 'config.h.meson',
@@ -368,12 +371,20 @@ _ibus_tests_cflags = []
 _ibus_link_args = []
 
 cc_default_multi_warn_arguments = [
-  ['-Wformat', '-Werror=format-security']
+  [ '-Werror=format-security' ]
 ]
 
 env_CFLAGS = run_command(python, '-c',
                          'import os; print(os.getenv("CFLAGS", ""))',
                          check: true).stdout().strip()
+env_CFLAGS_has_fortify = false
+
+foreach e : env_CFLAGS.split() + get_option('c_args')
+  if e.contains('-D_FORTIFY_SOURCE=')
+    env_CFLAGS_has_fortify = true
+    break
+  endif
+endforeach
 
 if buildtype == 'release'
   _ibus_cflags += [ '-DG_DISABLE_CAST_CHECKS', '-Wl,-z,relro', '-Wl,-z,now' ]
@@ -393,10 +404,22 @@ endif
 # Set default single arguments
 ibus_cflags =  cc.get_supported_arguments(_ibus_cflags)
 
+# Need '-Wall -O2 -D_FORTIFY_SOURCE=2' to enable '-Wunused-result'
+if not env_CFLAGS_has_fortify and get_option('optimization') != '0'
+  foreach i : [ 3, 2 ]
+    _ibus_cflags2 = '-D_FORTIFY_SOURCE=@0@'.format(i)
+    if cc.has_argument(_ibus_cflags2)
+      ibus_cflags += _ibus_cflags2
+      break
+    endif
+  endforeach
+endif
+
 # cc.get_supported_arguments() does not support long nested arguments
-if env_CFLAGS == ''
+if env_CFLAGS == '' and get_option('warning_level') != '0'
   foreach args : cc_default_multi_warn_arguments
-    if cc.has_multi_arguments(args)
+    test_args = [ '-Wall' ] + args
+    if cc.has_multi_arguments(test_args)
       ibus_cflags +=  args
     endif
   endforeach
@@ -494,7 +517,7 @@ summary({
   'Enable Unicode dict':           get_option('unicode-dict'),
   'UCD directory':                 get_option('ucd-dir'),
   'Socket directory':              ibus_socket_dir,
-  'XFixes client disconnect':      have_xfixes,
+  'XFixes client disconnect':      enable_xfixes,
   'Install systemd service':       enable_systemd,
 }, section: 'Components')
 

--- a/src/ibuskeys.c
+++ b/src/ibuskeys.c
@@ -45,12 +45,12 @@ const gchar*
 ibus_keyval_name (guint keyval)
 {
   static gchar buf[100];
-  gdk_key *found;
+  const gdk_key *found;
 
   /* <ohorn> with 0x01000000 is supported in gdk_keys_by_keyval */
 
-  found = bsearch (&keyval, gdk_keys_by_keyval,
-                   IBUS_NUM_KEYS, sizeof (gdk_key),
+  found = (const gdk_key *)bsearch (&keyval, gdk_keys_by_keyval,
+                                    IBUS_NUM_KEYS, sizeof (gdk_key),
            gdk_keys_keyval_compare);
 
   if (found != NULL)
@@ -80,13 +80,13 @@ gdk_keys_name_compare (const void *pkey, const void *pbase)
 guint
 ibus_keyval_from_name (const gchar *keyval_name)
 {
-  gdk_key *found;
+  const gdk_key *found;
 
   g_return_val_if_fail (keyval_name != NULL, 0);
 
-  found = bsearch (keyval_name, gdk_keys_by_name,
-           IBUS_NUM_KEYS, sizeof (gdk_key),
-           gdk_keys_name_compare);
+  found = (const gdk_key *)bsearch (keyval_name, gdk_keys_by_name,
+                                    IBUS_NUM_KEYS, sizeof (gdk_key),
+                                    gdk_keys_name_compare);
   if (found != NULL)
     return found->keyval;
   else

--- a/src/ibusutil.c
+++ b/src/ibusutil.c
@@ -139,14 +139,15 @@ _load_lang()
 const static gchar *
 ibus_get_untranslated_raw_language_name (const gchar *_locale)
 {
+    const gchar *sub;
     const gchar *retval;
     gchar *p = NULL;
     gchar *lang = NULL;
 
     if (__languages_dict == NULL )
         _load_lang();
-    if ((p = strchr (_locale, '_')) !=  NULL)
-        p = g_strndup (_locale, p - _locale);
+    if ((sub = (const gchar *)strchr (_locale, '_')) !=  NULL)
+        p = g_strndup (_locale, sub - _locale);
     else
         p = g_strdup (_locale);
     lang = g_ascii_strdown (p, -1);

--- a/src/tests/ibus-keypress.c
+++ b/src/tests/ibus-keypress.c
@@ -353,9 +353,17 @@ engine_focus_in_cb (IBusEngine *engine,
     m_engine_is_focused = g_strdup_printf ("%s%s\n",
                                            FOCUSED_ENGINE, "No named");
 #endif
-    write (m_sv[1], m_engine_is_focused,
-                             strlen (m_engine_is_focused) + 1);
-    fsync (m_sv[1]);
+    errno = 0;
+    /* Fix a warning: ignoring return value of ‘write’ declared with attribute
+     * ‘warn_unused_result’ [-Wunused-result]
+     * The '-Wunused-result' flag requires the C compiler optimization. E.g.
+     * CFLAGS='-Wall -g -O2 -D_FORTIFY_SOURCE=3'
+     */
+    if (write (m_sv[1], m_engine_is_focused,
+        strlen (m_engine_is_focused) + 1) < 0) {
+        g_warning ("Failed to send to FOCUSED_IN_ENGINE to parent: %s",
+                   g_strerror (errno));
+    }
 }
 
 
@@ -372,9 +380,11 @@ engine_focus_out_cb (IBusEngine *engine,
     g_test_message ("Engine:focus-out-cb()");
 #endif
     g_clear_pointer (&m_engine_is_focused, g_free);
-    write (m_sv[1], FOCUSED_ENGINE "\n",
-                             strlen (FOCUSED_ENGINE) + 2);
-    fsync (m_sv[1]);
+    errno = 0;
+    if (write (m_sv[1], FOCUSED_ENGINE "\n", strlen (FOCUSED_ENGINE) + 2) < 0) {
+        g_warning ("Failed to send to FOCUSED_OUT_ENGINE to parent: %s",
+                   g_strerror (errno));
+    }
 }
 
 
@@ -547,8 +557,11 @@ exec_ibus_engine ()
 
     g_main_loop_run (m_loop);
     if (_data.idle_id) {
-        write (m_sv[1], FAILED_ENGINE, sizeof (FAILED_ENGINE));
-        fsync (m_sv[1]);
+        errno = 0;
+        if (write (m_sv[1], FAILED_ENGINE, sizeof (FAILED_ENGINE)) < 0) {
+            g_warning ("Failed to send to FAILED_ENGINE to parent: %s",
+                       g_strerror (errno));
+        }
         close (m_sv[1]);
         exit (EXIT_FAILURE);
     }
@@ -815,8 +828,11 @@ window_inserted_text_cb (GtkEntryBuffer *buffer,
     if (!test_results[i][j]) {
         g_assert (!j);
 
-        write (m_sv[0], RECV_KEY, sizeof (RECV_KEY));
-        fsync (m_sv[0]);
+        errno = 0;
+        if (write (m_sv[0], RECV_KEY, sizeof (RECV_KEY)) < 0) {
+            g_warning ("Failed to send to RECV_KEY to child: %s",
+                       g_strerror (errno));
+        }
         g_info ("Sent RECV");
         /* Wait for calling ibus_quit() until the client receives RECV_KEY */
         data.idle_id = g_timeout_add_seconds (1, idle_cb, &data);

--- a/ui/gtk3/extension.vala
+++ b/ui/gtk3/extension.vala
@@ -26,8 +26,13 @@ class ExtensionGtk : Gtk.Application {
     private PanelBinding m_panel;
 
     public ExtensionGtk(string[] args) {
+#if GLIB_DEPRECATED_IN_2_74
+        GLib.ApplicationFlags flags = ApplicationFlags.DEFAULT_FLAGS;
+#else
+        GLib.ApplicationFlags flags = ApplicationFlags.FLAGS_NONE;
+#endif
         Object(application_id: "org.freedesktop.IBus.Panel.Extension.Gtk3",
-               flags: ApplicationFlags.FLAGS_NONE);
+               flags: flags);
         GLib.Intl.bindtextdomain(Config.GETTEXT_PACKAGE, Config.LOCALEDIR);
         GLib.Intl.bind_textdomain_codeset(Config.GETTEXT_PACKAGE, "UTF-8");
         IBus.init();

--- a/ui/gtk3/meson.build
+++ b/ui/gtk3/meson.build
@@ -71,6 +71,10 @@ ibus_ui_gtk3_cflags = [
 
 ibus_ui_gtk3_valaflags = []
 
+if glib_dep.version().version_compare('>= 2.74.0')
+  ibus_ui_gtk3_valaflags += [ '-D', 'GLIB_DEPRECATED_IN_2_74' ]
+endif
+
 if enable_xim
   ibus_ui_gtk3_deps += [ x11_dep, xi_vapi, gdk3_x11_dep, ]
   ibus_ui_gtk3_valaflags += [ '-D', 'ENABLE_XIM' ]


### PR DESCRIPTION
Five patches are applied:

- github/hook: Add PR id
- bindings/pygobject/test-deserialize: Update for no attribute
- bus/ibusimpl: Fix BusInputContext leak in bus_ibus_impl_init()
- Fix some build warnings
- meson: Add _FORTIFY_SOURCE flag to default CFLAGS