### PR TITLE
ui/gtk3: Fix fatal crash in get_xdisplay() on Wayland-only compositors

### DIFF
--- a/ui/gtk3/bindingcommon.vala
+++ b/ui/gtk3/bindingcommon.vala
@@ -272,6 +272,8 @@ class BindingCommon {
             return m_xdisplay;
         var display = Gdk.Display.get_default();
         if (display == null) {
+            if (check_only)
+                return null;
             error("You should open a display for IBus panel.");
         }
         Type instance_type = display.get_type();


### PR DESCRIPTION
BindingCommon.get_xdisplay() called error() unconditionally when
Gdk.Display.get_default() returned null. Since Vala's error()
compiles to g_error(), which is always fatal, this aborted the
whole ibus-ui-gtk3 process instead of just reporting no X display
was available.

This is reachable from default_is_xdisplay(), which calls
get_xdisplay(check_only: true) purely to probe whether an X
display exists. On compositors without XWayland readily available
at panel startup (observed on Sway), Gdk.Display.get_default()
returns null at that point, triggering the fatal error and
crashing ibus-ui-gtk3. The panel is relaunched immediately after,
which visually presents as the candidate window flashing and
disappearing.

Every other caller of get_xdisplay() already checks
default_is_xdisplay() first, so a real display is guaranteed by
the time the non-check_only path is reached. Only the check_only
path needs to return null gracefully instead of aborting.

Fixes #2946